### PR TITLE
Feat: 페이지에 Layout 적용

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-  "cSpell.words": ["signup", "tailwindcss", "tanstack", "taskify"]
+  "cSpell.words": [
+    "dashboardid",
+    "signup",
+    "tailwindcss",
+    "tanstack",
+    "taskify"
+  ]
 }

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import Image from "next/image";
+import { FC } from "react";
+
+const Footer: FC = () => {
+  return (
+    <div className='tablet:mx-[40px] tablet:flex tablet:justify-between desktop:mx-[141px]'>
+      <Link
+        href=''
+        className='mb-[12px] flex justify-center text-[12px] text-gray-40 tablet:text-[16px]'
+      >
+        ©codeit - 2023
+      </Link>
+      <div className='mx-auto mb-[68px] flex w-[117px] justify-between text-[12px] text-gray-40 tablet:mx-[0px] tablet:mb-[0px] tablet:w-[161px] tablet:text-[16px]'>
+        <Link href=''>Privacy Policy</Link>
+        <Link href=''>FAQ</Link>
+      </div>
+      <div className='mx-auto flex w-[93.27px] justify-between tablet:mx-[0px]'>
+        <Link href=''>
+          <Image
+            className='tablet:h-[20px] tablet:w-[20px]'
+            src='/icon/ic_message.svg'
+            alt='email icon'
+            width={18}
+            height={18}
+          />
+        </Link>
+        <Link href='https://www.facebook.com/?locale=ko_KR'>
+          <Image
+            className='tablet:h-[20px] tablet:w-[20px]'
+            src='/icon/ic_facebook.svg'
+            alt='facebook icon'
+            width={18}
+            height={18}
+          />
+        </Link>
+        <Link href='https://www.instagram.com/'>
+          <Image
+            className='tablet:h-[20px] tablet:w-[20px]'
+            src='/icon/ic_instagram.svg'
+            alt='instagram icon'
+            width={18}
+            height={18}
+          />
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default Footer;

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import NavMyDashboard from "@/components/Navbar/NavMyDashboard";
+import SideMenu from "@/components/SideMenu/SideMenu";
+
+interface NavMyDashboardProps {
+  children: ReactNode;
+}
+
+export default function DashboardLayout({ children }: NavMyDashboardProps) {
+  return (
+    <div>
+      <NavMyDashboard />
+      <SideMenu />
+      {children}
+    </div>
+  );
+}

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -1,22 +1,57 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import NavMyDashboard from "@/components/Navbar/NavMyDashboard";
 import SideMenu from "@/components/SideMenu/SideMenu";
+import { useAPI } from "@/hooks/useAPI";
+import { AxiosRequestConfig } from "axios";
+import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 
 interface DashboardLayoutProps {
   children: ReactNode;
   title: string;
+  dashboardid?: string;
   showActionButton?: boolean;
   showBadgeCounter?: boolean;
   showProfileDropdown?: boolean;
+  fetchDashboardData?: boolean;
 }
 
-export default function DashboardLayout({
+const DashboardLayout = ({
   children,
   title,
+  dashboardid,
   showActionButton = true,
   showBadgeCounter = true,
   showProfileDropdown = true,
-}: DashboardLayoutProps) {
+  fetchDashboardData = true,
+}: DashboardLayoutProps) => {
+  let dashboardData = null;
+
+  if (fetchDashboardData) {
+    const token =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
+
+    const dashboardConfig: AxiosRequestConfig = {
+      url: `/dashboards/${dashboardid}`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
+    const { data } = useAPI<DashboardDetailResponse>(
+      `dashboardData-${dashboardid}`,
+      dashboardConfig,
+    );
+
+    dashboardData = data;
+  }
+
+  useEffect(() => {
+    if (dashboardData) {
+      console.log("Dashboard Data:", dashboardData);
+    }
+  }, [dashboardData]);
+
   return (
     <div>
       <NavMyDashboard
@@ -29,4 +64,6 @@ export default function DashboardLayout({
       {children}
     </div>
   );
-}
+};
+
+export default DashboardLayout;

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -8,11 +8,10 @@ import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 interface DashboardLayoutProps {
   children: ReactNode;
   title: string;
-  dashboardid?: string;
+  dashboardid: string;
   showActionButton?: boolean;
   showBadgeCounter?: boolean;
   showProfileDropdown?: boolean;
-  fetchDashboardData?: boolean;
 }
 
 const DashboardLayout = ({
@@ -22,29 +21,26 @@ const DashboardLayout = ({
   showActionButton = true,
   showBadgeCounter = true,
   showProfileDropdown = true,
-  fetchDashboardData = true,
 }: DashboardLayoutProps) => {
-  let dashboardData = null;
+  const token =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
 
-  if (fetchDashboardData) {
-    const token =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
+  const dashboardConfig: AxiosRequestConfig = {
+    url: `/dashboards/${dashboardid}`,
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
 
-    const dashboardConfig: AxiosRequestConfig = {
-      url: `/dashboards/${dashboardid}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    };
-
-    const { data } = useAPI<DashboardDetailResponse>(
-      `dashboardData-${dashboardid}`,
-      dashboardConfig,
-    );
-
-    dashboardData = data;
-  }
+  const {
+    data: dashboardData,
+    error: dashboardError,
+    isLoading: dashboardLoading,
+  } = useAPI<DashboardDetailResponse>(
+    `dashboardData-${dashboardid}`,
+    dashboardConfig,
+  );
 
   useEffect(() => {
     if (dashboardData) {
@@ -52,10 +48,19 @@ const DashboardLayout = ({
     }
   }, [dashboardData]);
 
+  if (dashboardLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (dashboardError || !dashboardData) {
+    return <div>데이터를 불러오는 중 오류가 발생했습니다</div>;
+  }
+
   return (
     <div>
       <NavMyDashboard
         title={title}
+        createdByMe={dashboardData.createdByMe}
         showActionButton={showActionButton}
         showBadgeCounter={showBadgeCounter}
         showProfileDropdown={showProfileDropdown}

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -2,14 +2,29 @@ import { ReactNode } from "react";
 import NavMyDashboard from "@/components/Navbar/NavMyDashboard";
 import SideMenu from "@/components/SideMenu/SideMenu";
 
-interface NavMyDashboardProps {
+interface DashboardLayoutProps {
   children: ReactNode;
+  title: string;
+  showActionButton?: boolean;
+  showBadgeCounter?: boolean;
+  showProfileDropdown?: boolean;
 }
 
-export default function DashboardLayout({ children }: NavMyDashboardProps) {
+export default function DashboardLayout({
+  children,
+  title,
+  showActionButton = true,
+  showBadgeCounter = true,
+  showProfileDropdown = true,
+}: DashboardLayoutProps) {
   return (
     <div>
-      <NavMyDashboard />
+      <NavMyDashboard
+        title={title}
+        showActionButton={showActionButton}
+        showBadgeCounter={showBadgeCounter}
+        showProfileDropdown={showProfileDropdown}
+      />
       <SideMenu />
       {children}
     </div>

--- a/components/Layout/HomeLayout.tsx
+++ b/components/Layout/HomeLayout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import NavMain from "@/components/Navbar/NavMain";
+import Footer from "@/components/Footer";
+
+interface HomeLayoutProps {
+  children: ReactNode;
+}
+
+export default function HomeLayout({ children }: HomeLayoutProps) {
+  return (
+    <div className='bg-black pb-[90px] tablet:pb-[40px] desktop:pb-[40px]'>
+      <NavMain />
+      {children}
+      <Footer />
+    </div>
+  );
+}

--- a/components/Navbar/NavMain.tsx
+++ b/components/Navbar/NavMain.tsx
@@ -15,7 +15,7 @@ const NavMain: FC = () => {
 
   return (
     <div
-      className={`flex h-[240px] items-center justify-between p-6 tablet:h-[280px] desktop:h-[320px] ${isLandingPage ? "bg-black text-white" : "bg-white text-black-20"}`}
+      className={`flex h-[60px] items-center justify-between p-6 tablet:h-[70px] desktop:h-[70px] ${isLandingPage ? "bg-black text-white" : "bg-white text-black-20"}`}
     >
       {/* 로고 */}
       <div className='flex items-center space-x-2'>

--- a/components/Navbar/NavMyDashboard.tsx
+++ b/components/Navbar/NavMyDashboard.tsx
@@ -12,7 +12,19 @@ import ProfileDropdown from "./Dropdown/ProfileDropdown";
 import { User } from "@/lib/api/types/users";
 import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 
-const MyDashboard: FC = () => {
+interface NavMyDashboardProps {
+  title: string;
+  showActionButton?: boolean;
+  showBadgeCounter?: boolean;
+  showProfileDropdown?: boolean;
+}
+
+const NavMyDashboard: FC<NavMyDashboardProps> = ({
+  title,
+  showActionButton = true,
+  showBadgeCounter = true,
+  showProfileDropdown = true,
+}) => {
   const token =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
 
@@ -66,31 +78,34 @@ const MyDashboard: FC = () => {
     <>
       <div className='h-[60px] content-center border-b border-gray-30 bg-white p-4 tablet:h-[70px] desktop:h-[80px]'>
         <div className='flex items-center justify-between'>
-          <NavbarTitle
-            title={dashboardData.title}
-            createdByMe={dashboardData.createdByMe}
-          />
+          <NavbarTitle title={title} createdByMe={false} />
 
           {/*Nav 우측: 버튼(관리, 초대하기) + 계정 프로필 (뱃지, 이름)*/}
           <div className='ml-auto mr-2 flex items-center justify-end space-x-4 text-sm tablet:mr-10 tablet:space-x-8 tablet:text-base desktop:mr-20 desktop:space-x-10 desktop:text-base'>
             <div className='flex space-x-2 whitespace-nowrap font-medium text-gray-50 tablet:space-x-3 desktop:space-x-8'>
-              <ActionButton label='관리' iconSrc='/icon/ic_setting.svg' />
-              <ActionButton
-                label='초대하기'
-                iconSrc='/icon/ic_add_dashboard.svg'
-              />
+              {showActionButton && (
+                <>
+                  <ActionButton label='관리' iconSrc='/icon/ic_setting.svg' />
+                  <ActionButton
+                    label='초대하기'
+                    iconSrc='/icon/ic_add_dashboard.svg'
+                  />
+                </>
+              )}
             </div>
 
-            <div className='flex items-center space-x-3 tablet:space-x-6 desktop:space-x-8'>
-              <BadgeCounter />
+            {showProfileDropdown && (
+              <div className='flex items-center space-x-3 tablet:space-x-6 desktop:space-x-8'>
+                {showBadgeCounter && <BadgeCounter />}
 
-              <span className='font-bold'>|</span>
+                <span className='font-bold'>|</span>
 
-              <ProfileDropdown
-                nickname={userData.nickname}
-                profileInitial={profileInitial}
-              />
-            </div>
+                <ProfileDropdown
+                  nickname={userData.nickname}
+                  profileInitial={profileInitial}
+                />
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -98,4 +113,4 @@ const MyDashboard: FC = () => {
   );
 };
 
-export default MyDashboard;
+export default NavMyDashboard;

--- a/components/Navbar/NavMyDashboard.tsx
+++ b/components/Navbar/NavMyDashboard.tsx
@@ -64,7 +64,7 @@ const MyDashboard: FC = () => {
 
   return (
     <>
-      <div className='h-[60px] content-center border-b border-gray-30 p-4 tablet:h-[70px] desktop:h-[80px]'>
+      <div className='h-[60px] content-center border-b border-gray-30 bg-white p-4 tablet:h-[70px] desktop:h-[80px]'>
         <div className='flex items-center justify-between'>
           <NavbarTitle
             title={dashboardData.title}

--- a/components/Navbar/NavMyDashboard.tsx
+++ b/components/Navbar/NavMyDashboard.tsx
@@ -1,19 +1,18 @@
 /* 
 MyDashboard 내비게이션 컴포넌트: API 연결 추후 수정 예정
  */
-
 import { FC, useEffect } from "react";
 import { AxiosRequestConfig } from "axios";
-import { useAPI } from "@/hooks/useAPI"; //
+import { useAPI } from "@/hooks/useAPI";
 import NavbarTitle from "./NavbarTitle";
 import ActionButton from "./ActionButton";
 import BadgeCounter from "./BadgeCounter";
 import ProfileDropdown from "./Dropdown/ProfileDropdown";
 import { User } from "@/lib/api/types/users";
-import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 
 interface NavMyDashboardProps {
   title: string;
+  createdByMe: boolean;
   showActionButton?: boolean;
   showBadgeCounter?: boolean;
   showProfileDropdown?: boolean;
@@ -21,6 +20,7 @@ interface NavMyDashboardProps {
 
 const NavMyDashboard: FC<NavMyDashboardProps> = ({
   title,
+  createdByMe,
   showActionButton = true,
   showBadgeCounter = true,
   showProfileDropdown = true,
@@ -37,14 +37,6 @@ const NavMyDashboard: FC<NavMyDashboardProps> = ({
     },
   };
 
-  const dashboardConfig: AxiosRequestConfig = {
-    url: "/dashboards/9807",
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  };
-
   // useAPI 훅 사용하여 사용자 데이터 불러오기
   const {
     data: userData,
@@ -52,23 +44,15 @@ const NavMyDashboard: FC<NavMyDashboardProps> = ({
     isLoading: userLoading,
   } = useAPI<User>("userData", userConfig);
 
-  // useAPI 훅 사용하여 대시보드 데이터 불러오기
-  const {
-    data: dashboardData,
-    error: dashboardError,
-    isLoading: dashboardLoading,
-  } = useAPI<DashboardDetailResponse>("dashboardData", dashboardConfig);
-
   useEffect(() => {
     console.log("User Data:", userData);
-    console.log("Dashboard Data:", dashboardData);
-  }, [userData, dashboardData]);
+  }, [userData]);
 
-  if (userLoading || dashboardLoading) {
+  if (userLoading) {
     return <div>Loading...</div>;
   }
 
-  if (userError || dashboardError || !userData || !dashboardData) {
+  if (userError || !userData) {
     return <div>데이터를 불러오는 중 오류가 발생했습니다</div>;
   }
 
@@ -78,7 +62,7 @@ const NavMyDashboard: FC<NavMyDashboardProps> = ({
     <>
       <div className='h-[60px] content-center border-b border-gray-30 bg-white p-4 tablet:h-[70px] desktop:h-[80px]'>
         <div className='flex items-center justify-between'>
-          <NavbarTitle title={title} createdByMe={false} />
+          <NavbarTitle title={title} createdByMe={createdByMe} />
 
           {/*Nav 우측: 버튼(관리, 초대하기) + 계정 프로필 (뱃지, 이름)*/}
           <div className='ml-auto mr-2 flex items-center justify-end space-x-4 text-sm tablet:mr-10 tablet:space-x-8 tablet:text-base desktop:mr-20 desktop:space-x-10 desktop:text-base'>

--- a/components/Navbar/NavbarTitle/index.tsx
+++ b/components/Navbar/NavbarTitle/index.tsx
@@ -20,7 +20,7 @@ const NavbarTitle: FC<NavbarTitleProps> = ({ title, createdByMe }) => {
           {title}
           {createdByMe && (
             <Image
-              src='icon/ic_crown.svg'
+              src='/icon/ic_crown.svg'
               alt='createdByMe'
               width={20}
               height={16}

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -39,48 +39,59 @@ async function fetchData(): Promise<UserData> {
             const addArray = (i:number) => {
 
 */
-    
-const SideMenu = () =>{
+
+const SideMenu = () => {
   //로고 컴포넌트
   const LogoButton = () => {
-    return(
-      <button className="flex items-center w-[109px] h-[33px] fixed top-[20px] left-[24px] max-tablet:w-[67px]">
-          <img src="/logo/logo_img.svg" className="w-[30px] h-auto max-tablet:w-[24px]"/>
-          <img src="/logo/logo_txt.svg" className="w-[80px] h-[22px] max-tablet:hidden"/>
+    return (
+      <button className='fixed left-[24px] top-[20px] flex h-[33px] w-[109px] items-center max-tablet:w-[67px]'>
+        <img
+          src='/logo/logo_img.svg'
+          className='h-auto w-[30px] max-tablet:w-[24px]'
+        />
+        <img
+          src='/logo/logo_txt.svg'
+          className='h-[22px] w-[80px] max-tablet:hidden'
+        />
       </button>
-    )
-  }
+    );
+  };
   //버튼 리스트의 추가 버튼 컴포넌트
   const AddButton = () => {
-    return(
-      <button className="flex justify-between items-center w-[276px] h-[20px] max-tablet:justify-center max-desktop:w-[112px] max-tablet:w-[67px]">
-        <p className="text-[12px] max-tablet:hidden">Dash Boards</p>
-        <img src="/icon/ic_add_dashboard.svg" className="w-[14px] h-[14px] "/>
+    return (
+      <button className='flex h-[20px] w-[276px] items-center justify-between max-desktop:w-[112px] max-tablet:w-[67px] max-tablet:justify-center'>
+        <p className='text-[12px] max-tablet:hidden'>Dash Boards</p>
+        <img src='/icon/ic_add_dashboard.svg' className='h-[14px] w-[14px]' />
       </button>
-    )}
+    );
+  };
 
-//아래 컴포넌트 수정 예정
-//추후 api 연동해 버튼 렌더링
+  //아래 컴포넌트 수정 예정
+  //추후 api 연동해 버튼 렌더링
   const ButtonList = () => {
-    return(
-      <div className="flex flex-col justify-center items-start w-full h-auto max-tablet:items-center">
-        <button className="flex justify-start items-center gap-[16px] max-tablet:w-[40px] max-tablet:justify-center max-desktop:w-[112px]">
-          <img src="/chip/circle.svg" className="w-[8px] h-[8px]"/>
-          <p className='text-[16px] max-tablet:hidden max-desktop:text-[14px]'>임의의 제목</p>
+    return (
+      <div className='flex h-auto w-full flex-col items-start justify-center max-tablet:items-center'>
+        <button className='flex items-center justify-start gap-[16px] max-desktop:w-[112px] max-tablet:w-[40px] max-tablet:justify-center'>
+          <img src='/chip/circle.svg' className='h-[8px] w-[8px]' />
+          <p className='text-[16px] max-desktop:text-[14px] max-tablet:hidden'>
+            임의의 제목
+          </p>
         </button>
       </div>
-      )
-  }
-        
-  return(
-    <div className='flex flex-col justify-start items-center gap-[40px] fixed top-0 left-0 border-r-[1px] border-gray-30 h-full w-[300px] max-desktop:w-[160px] max-tablet:w-[67px]'>
-      <Link href="/"><LogoButton/></Link>
-      <div className="flex flex-col justify-start items-center gap-[22px] fixed left-[12px] top-[110px] w-[276px] h-full max-tablet:top-[60px] max-desktop:w-[134px] max-tablet:w-[67px] max-tablet:left-0">
-        <AddButton/>
-        <ButtonList/>
+    );
+  };
+
+  return (
+    <div className='fixed left-0 top-0 flex h-full w-[300px] flex-col items-center justify-start gap-[40px] border-r-[1px] border-gray-30 bg-white max-desktop:w-[160px] max-tablet:w-[67px]'>
+      <Link href='/'>
+        <LogoButton />
+      </Link>
+      <div className='fixed left-[12px] top-[110px] flex h-full w-[276px] flex-col items-center justify-start gap-[22px] max-desktop:w-[134px] max-tablet:left-0 max-tablet:top-[60px] max-tablet:w-[67px]'>
+        <AddButton />
+        <ButtonList />
       </div>
     </div>
-  )
-}
+  );
+};
 
 export default SideMenu;

--- a/hooks/useAPI.ts
+++ b/hooks/useAPI.ts
@@ -15,15 +15,16 @@ const fetchAPI = async <T>(config: AxiosRequestConfig): Promise<T> => {
 
 // 공용 훅
 export const useAPI = <T>(
-  key: string,
-  config: AxiosRequestConfig,
+  key: string | null,
+  config: AxiosRequestConfig | null,
 ): UseQueryResult<T> => {
   const [, setApiData] = useAtom(apiDataAtom);
   const queryKey = [key, config];
 
   const queryResult = useQuery<T>({
     queryKey: queryKey,
-    queryFn: () => fetchAPI<T>(config),
+    queryFn: () =>
+      config ? fetchAPI<T>(config) : Promise.reject("No config provided"),
   });
 
   useEffect(() => {

--- a/hooks/useAPI.ts
+++ b/hooks/useAPI.ts
@@ -9,6 +9,7 @@ export const apiDataAtom = atom<any>(null);
 
 // API 요청 함수
 const fetchAPI = async <T>(config: AxiosRequestConfig): Promise<T> => {
+  console.log("Fetching API with config:", config);
   const response: AxiosResponse<T> = await fetcher<T>(config);
   return response.data;
 };
@@ -19,12 +20,12 @@ export const useAPI = <T>(
   config: AxiosRequestConfig | null,
 ): UseQueryResult<T> => {
   const [, setApiData] = useAtom(apiDataAtom);
-  const queryKey = [key, config];
+  const queryKey = key ? [key, config] : [];
 
   const queryResult = useQuery<T>({
-    queryKey: queryKey,
-    queryFn: () =>
-      config ? fetchAPI<T>(config) : Promise.reject("No config provided"),
+    queryKey: queryKey as [string, AxiosRequestConfig],
+    queryFn: () => fetchAPI<T>(config as AxiosRequestConfig),
+    enabled: !!key && !!config,
   });
 
   useEffect(() => {
@@ -32,6 +33,12 @@ export const useAPI = <T>(
       setApiData(queryResult.data);
     }
   }, [queryResult.data, setApiData]);
+
+  useEffect(() => {
+    if (queryResult.error) {
+      console.error("Error fetching API:", queryResult.error);
+    }
+  }, [queryResult.error]);
 
   return queryResult;
 };

--- a/pages/dashboard/[dashboardid]/edit.tsx
+++ b/pages/dashboard/[dashboardid]/edit.tsx
@@ -1,3 +1,63 @@
-export default function Edit() {
-  return <></>;
-}
+import { useRouter } from "next/router";
+import DashboardLayout from "@/components/Layout/DashboardLayout";
+import { useAPI } from "@/hooks/useAPI";
+import { AxiosRequestConfig } from "axios";
+import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
+
+const DashboardEditPage = () => {
+  const router = useRouter();
+  const { dashboardid } = router.query;
+
+  // dashboardId 콘솔에 출력하여 확인
+  console.log("Router Query:", router.query);
+  console.log("Dashboard ID:", dashboardid);
+
+  if (!dashboardid || Array.isArray(dashboardid)) {
+    return <div>유효하지 않은 대시보드 ID</div>;
+  }
+
+  const token =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
+
+  const dashboardConfig: AxiosRequestConfig = {
+    url: `/dashboards/${dashboardid}`,
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
+  const {
+    data: dashboardData,
+    error: dashboardError,
+    isLoading: dashboardLoading,
+  } = useAPI<DashboardDetailResponse>(
+    `dashboardData-${dashboardid}`,
+    dashboardConfig,
+  );
+
+  if (dashboardLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (dashboardError || !dashboardData) {
+    return <div>데이터를 불러오는 중 오류가 발생했습니다</div>;
+  }
+
+  return (
+    <DashboardLayout
+      title={`${dashboardData.title}`}
+      dashboardid={dashboardid as string}
+      showActionButton={true}
+      showBadgeCounter={true}
+      showProfileDropdown={true}
+    >
+      <div>
+        <h1>대시보드 편집</h1>
+        {/* 편집할 대시보드 데이터 표시 */}
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default DashboardEditPage;

--- a/pages/dashboard/[dashboardid]/index.tsx
+++ b/pages/dashboard/[dashboardid]/index.tsx
@@ -1,11 +1,48 @@
+import { useRouter } from "next/router";
 import DashboardLayout from "@/components/Layout/DashboardLayout";
+import { useAPI } from "@/hooks/useAPI";
+import { AxiosRequestConfig } from "axios";
+import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 
-export default function DashBoard() {
+const DashboardPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const token =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
+
+  const dashboardConfig: AxiosRequestConfig = {
+    url: `/dashboards/${id}`,
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
+  const {
+    data: dashboardData,
+    error: dashboardError,
+    isLoading: dashboardLoading,
+  } = useAPI<DashboardDetailResponse>("dashboardData", dashboardConfig);
+
+  if (dashboardLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (dashboardError || !dashboardData) {
+    return <div>데이터를 불러오는 중 오류가 발생했습니다</div>;
+  }
+
   return (
-    <>
-      <DashboardLayout>
-        <div></div>
-      </DashboardLayout>
-    </>
+    <DashboardLayout
+      title={dashboardData.title}
+      showActionButton={true}
+      showBadgeCounter={true}
+      showProfileDropdown={true}
+    >
+      <div>{/* DashboardPage의 콘텐츠 */}</div>
+    </DashboardLayout>
   );
-}
+};
+
+export default DashboardPage;

--- a/pages/dashboard/[dashboardid]/index.tsx
+++ b/pages/dashboard/[dashboardid]/index.tsx
@@ -4,15 +4,23 @@ import { useAPI } from "@/hooks/useAPI";
 import { AxiosRequestConfig } from "axios";
 import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 
-const DashboardPage = () => {
+const DashboardEditPage = () => {
   const router = useRouter();
-  const { id } = router.query;
+  const { dashboardid } = router.query;
+
+  // dashboardId 콘솔에 출력하여 확인
+  console.log("Router Query:", router.query);
+  console.log("Dashboard ID:", dashboardid);
+
+  if (!dashboardid || Array.isArray(dashboardid)) {
+    return <div>유효하지 않은 대시보드 ID</div>;
+  }
 
   const token =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
 
   const dashboardConfig: AxiosRequestConfig = {
-    url: `/dashboards/${id}`,
+    url: `/dashboards/${dashboardid}`,
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -23,10 +31,13 @@ const DashboardPage = () => {
     data: dashboardData,
     error: dashboardError,
     isLoading: dashboardLoading,
-  } = useAPI<DashboardDetailResponse>("dashboardData", dashboardConfig);
+  } = useAPI<DashboardDetailResponse>(
+    `dashboardData-${dashboardid}`,
+    dashboardConfig,
+  );
 
   if (dashboardLoading) {
-    return <div>Loading...</div>;
+    return <div>로딩 중...</div>;
   }
 
   if (dashboardError || !dashboardData) {
@@ -35,14 +46,18 @@ const DashboardPage = () => {
 
   return (
     <DashboardLayout
-      title={dashboardData.title}
+      title={`${dashboardData.title}`}
+      dashboardid={dashboardid as string}
       showActionButton={true}
       showBadgeCounter={true}
       showProfileDropdown={true}
     >
-      <div>{/* DashboardPage의 콘텐츠 */}</div>
+      <div>
+        <h1>대시보드</h1>
+        {/* 대시보드 페이지 본문 */}
+      </div>
     </DashboardLayout>
   );
 };
 
-export default DashboardPage;
+export default DashboardEditPage;

--- a/pages/dashboard/[dashboardid]/index.tsx
+++ b/pages/dashboard/[dashboardid]/index.tsx
@@ -1,3 +1,11 @@
+import DashboardLayout from "@/components/Layout/DashboardLayout";
+
 export default function DashBoard() {
-  return <></>;
+  return (
+    <>
+      <DashboardLayout>
+        <div></div>
+      </DashboardLayout>
+    </>
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,183 +1,141 @@
+import HomeLayout from "@/components/Layout/HomeLayout";
 import Image from "next/image";
-import NavMain from "@/components/Navbar/NavMain";
-import Link from "next/link";
 import LinkButton from "@/components/Button/LinkButton/LinkButton";
 
 export default function Home() {
   return (
-    <div className='bg-black pb-[90px] tablet:pb-[40px]'>
-      <NavMain />
-      <div className='mx-auto mb-[84px] mt-[42px] w-[287px] tablet:mb-[200px] tablet:mt-[74px] tablet:w-[768px] desktop:mb-[200px] desktop:mt-[74px] desktop:w-[1000px]'>
-        <Image
-          className='mx-auto mb-[21px] tablet:mb-[30px] tablet:w-[537px] desktop:mb-[30px] desktop:w-[722px]'
-          src='/img_landing/illustration.png'
-          alt='illustration'
-          width={287}
-          height={168}
-          sizes='(max-width: 768px) 287px, (max-width: 1200px) 537px, 722px'
-        />
-        <div className='text-center'>
-          <span className='text-[36px] font-bold text-white tablet:text-[56px] desktop:text-[76px]'>
-            새로운 일정 관리
-            <span className='block text-[38px] font-bold text-violet-20 tablet:inline tablet:text-[70px] desktop:text-[90px]'>
-              &nbsp;Taskify
-            </span>
-          </span>
-          <h4 className='mb-[63px] mt-[21px] text-center text-[12px] text-white tablet:text-[16px] desktop:text-[18px]'>
-            스마트하게 나의 일정을 관리해보자!
-          </h4>
+    <HomeLayout>
+      <div className='pb-[90px] tablet:pb-[40px]'>
+        <div className='mx-auto mb-[84px] mt-[42px] w-[287px] tablet:mb-[200px] tablet:mt-[74px] tablet:w-[768px] desktop:mb-[200px] desktop:mt-[74px] desktop:w-[1000px]'>
+          <Image
+            className='mx-auto mb-[21px] tablet:mb-[30px] tablet:w-[537px] desktop:mb-[30px] desktop:w-[722px]'
+            src='/img_landing/illustration.png'
+            alt='illustration'
+            width={287}
+            height={168}
+            sizes='(max-width: 768px) 287px, (max-width: 1200px) 537px, 722px'
+          />
           <div className='text-center'>
-            <LinkButton
-              to='/login'
-              children='로그인하기'
-              className='h-[42px] w-[235.2px] text-[14px] font-medium tablet:h-[50px] tablet:w-[280px] tablet:text-[16px]'
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className='relative mx-auto mb-[64px] h-[686px] w-[343px] rounded-lg bg-black-30 pt-[99px] tablet:h-[972px] tablet:w-[664px] desktop:h-[600px] desktop:w-[1200px]'>
-        <div className='text-center tablet:ml-[60px] tablet:text-left'>
-          <h3 className='mb-[66px] text-[18px] font-medium text-gray-40 tablet:mb-[108px] tablet:text-[22px] tablet:font-medium desktop:mb-[108px]'>
-            Point1
-          </h3>
-          <h1 className='text-[36px] font-bold text-white tablet:text-[48px]'>
-            일의 우선순위를
-            <br />
-            관리하세요
-          </h1>
-        </div>
-        <Image
-          className='absolute bottom-0 right-0 tablet:w-[519px] desktop:w-[594px]'
-          src='/img_landing/img_point2.svg'
-          alt='point1 image'
-          width={296}
-          height={248}
-        />
-      </div>
-
-      <div className='relative mx-auto h-[686px] w-[343px] rounded-lg bg-black-30 pt-[99px] tablet:h-[972px] tablet:w-[664px] desktop:flex desktop:h-[600px] desktop:w-[1200px] desktop:flex-row-reverse'>
-        <div className='text-center tablet:ml-[60px] tablet:text-left desktop:absolute desktop:left-1/2'>
-          <h3 className='mb-[66px] text-[18px] font-medium text-gray-40 tablet:mb-[108px] tablet:text-[22px] tablet:font-medium desktop:mb-[108px]'>
-            Point2
-          </h3>
-          <h1 className='text-[36px] font-bold text-white tablet:text-[48px]'>
-            해야 할 일을
-            <br />
-            등록하세요
-          </h1>
-        </div>
-        <Image
-          className='absolute bottom-0 left-1/2 -ml-[108.5px] tablet:-ml-[180px] tablet:w-[360px] desktop:-ml-[500px] desktop:w-[436px]'
-          src='/img_landing/img_point3.svg'
-          alt='point1 image'
-          width={216}
-          height={250}
-        />
-      </div>
-
-      <div className='mx-auto mt-[90px] desktop:w-[1200px] desktop:flex-col'>
-        <h2 className='mb-[32px] text-center text-[22px] font-bold text-white tablet:text-[28px] desktop:text-left'>
-          생산성을 높이는 다양한 설정 ⚡
-        </h2>
-        <div className='mx-auto my-0 desktop:flex desktop:w-[1200px] desktop:justify-between'>
-          <div className='mb-[40px]'>
-            <div className='mx-auto my-0 flex h-[235.93px] w-[343px] justify-center rounded-t-lg bg-black-10 tablet:h-[260px] tablet:w-[378px]'>
-              <Image
-                className='mx-auto my-0 tablet:w-[300px]'
-                src='/img_landing/img_bottom1.svg'
-                alt='bottom image 1'
-                width={260}
-                height={107.35}
+            <span className='text-[36px] font-bold text-white tablet:text-[56px] desktop:text-[76px]'>
+              새로운 일정 관리
+              <span className='block text-[38px] font-bold text-violet-20 tablet:inline tablet:text-[70px] desktop:text-[90px]'>
+                &nbsp;Taskify
+              </span>
+            </span>
+            <h4 className='mb-[63px] mt-[21px] text-center text-[12px] text-white tablet:text-[16px] desktop:text-[18px]'>
+              스마트하게 나의 일정을 관리해보자!
+            </h4>
+            <div className='text-center'>
+              <LinkButton
+                to='/login'
+                children='로그인하기'
+                className='h-[42px] w-[235.2px] text-[14px] font-medium tablet:h-[50px] tablet:w-[280px] tablet:text-[16px]'
               />
             </div>
-            <div className='mx-auto my-0 flex h-[112.52px] w-[343px] flex-col justify-between rounded-b-lg bg-black-30 p-7 text-white tablet:h-[124px] tablet:w-[378px]'>
-              <h3 className='text-[18px] font-bold'>대시보드 설정</h3>
-              <h4 className='text-[14px] font-medium'>
-                대시보드 사진과 이름을 변경할 수 있어요.
-              </h4>
-            </div>
           </div>
+        </div>
 
-          <div className='mb-[40px]'>
-            <div className='mx-auto my-0 flex h-[235.93px] w-[343px] justify-center rounded-t-lg bg-black-10 tablet:h-[260px] tablet:w-[378px]'>
-              <Image
-                className='mx-auto my-0 tablet:w-[300px]'
-                src='/img_landing/img_bottom2.svg'
-                alt='bottom image 1'
-                width={260}
-                height={107.35}
-              />
-            </div>
-            <div className='mx-auto my-0 flex h-[112.52px] w-[343px] flex-col justify-between rounded-b-lg bg-black-30 p-7 text-white tablet:h-[124px] tablet:w-[378px]'>
-              <h3 className='text-[18px] font-bold'>초대</h3>
-              <h4 className='text-[14px] font-medium'>
-                새로운 팀원을 초대할 수 있어요.
-              </h4>
-            </div>
+        <div className='relative mx-auto mb-[64px] h-[686px] w-[343px] rounded-lg bg-black-30 pt-[99px] tablet:h-[972px] tablet:w-[664px] desktop:h-[600px] desktop:w-[1200px]'>
+          <div className='text-center tablet:ml-[60px] tablet:text-left'>
+            <h3 className='mb-[66px] text-[18px] font-medium text-gray-40 tablet:mb-[108px] tablet:text-[22px] tablet:font-medium desktop:mb-[108px]'>
+              Point1
+            </h3>
+            <h1 className='text-[36px] font-bold text-white tablet:text-[48px]'>
+              일의 우선순위를
+              <br />
+              관리하세요
+            </h1>
           </div>
+          <Image
+            className='absolute bottom-0 right-0 tablet:w-[519px] desktop:w-[594px]'
+            src='/img_landing/img_point2.svg'
+            alt='point1 image'
+            width={296}
+            height={248}
+          />
+        </div>
 
-          <div className='mb-[120px]'>
-            <div className='mx-auto my-0 flex h-[235.93px] w-[343px] justify-center rounded-t-lg bg-black-10 tablet:h-[260px] tablet:w-[378px]'>
-              <Image
-                className='mx-auto my-0 tablet:w-[300px]'
-                src='/img_landing/img_bottom3.svg'
-                alt='bottom image 1'
-                width={260}
-                height={107.35}
-              />
+        <div className='relative mx-auto h-[686px] w-[343px] rounded-lg bg-black-30 pt-[99px] tablet:h-[972px] tablet:w-[664px] desktop:flex desktop:h-[600px] desktop:w-[1200px] desktop:flex-row-reverse'>
+          <div className='text-center tablet:ml-[60px] tablet:text-left desktop:absolute desktop:left-1/2'>
+            <h3 className='mb-[66px] text-[18px] font-medium text-gray-40 tablet:mb-[108px] tablet:text-[22px] tablet:font-medium desktop:mb-[108px]'>
+              Point2
+            </h3>
+            <h1 className='text-[36px] font-bold text-white tablet:text-[48px]'>
+              해야 할 일을
+              <br />
+              등록하세요
+            </h1>
+          </div>
+          <Image
+            className='absolute bottom-0 left-1/2 -ml-[108.5px] tablet:-ml-[180px] tablet:w-[360px] desktop:-ml-[500px] desktop:w-[436px]'
+            src='/img_landing/img_point3.svg'
+            alt='point1 image'
+            width={216}
+            height={250}
+          />
+        </div>
+
+        <div className='mx-auto mt-[90px] desktop:w-[1200px] desktop:flex-col'>
+          <h2 className='mb-[32px] text-center text-[22px] font-bold text-white tablet:text-[28px] desktop:text-left'>
+            생산성을 높이는 다양한 설정 ⚡
+          </h2>
+          <div className='mx-auto my-0 desktop:flex desktop:w-[1200px] desktop:justify-between'>
+            <div className='mb-[40px]'>
+              <div className='mx-auto my-0 flex h-[235.93px] w-[343px] justify-center rounded-t-lg bg-black-10 tablet:h-[260px] tablet:w-[378px]'>
+                <Image
+                  className='mx-auto my-0 tablet:w-[300px]'
+                  src='/img_landing/img_bottom1.svg'
+                  alt='bottom image 1'
+                  width={260}
+                  height={107.35}
+                />
+              </div>
+              <div className='mx-auto my-0 flex h-[112.52px] w-[343px] flex-col justify-between rounded-b-lg bg-black-30 p-7 text-white tablet:h-[124px] tablet:w-[378px]'>
+                <h3 className='text-[18px] font-bold'>대시보드 설정</h3>
+                <h4 className='text-[14px] font-medium'>
+                  대시보드 사진과 이름을 변경할 수 있어요.
+                </h4>
+              </div>
             </div>
-            <div className='mx-auto my-0 flex h-[112.52px] w-[343px] flex-col justify-between rounded-b-lg bg-black-30 p-7 text-white tablet:h-[124px] tablet:w-[378px]'>
-              <h3 className='text-[18px] font-bold'>구성원</h3>
-              <h4 className='text-[14px] font-medium'>
-                구성원을 초대하고 내보낼 수 있어요.
-              </h4>
+
+            <div className='mb-[40px]'>
+              <div className='mx-auto my-0 flex h-[235.93px] w-[343px] justify-center rounded-t-lg bg-black-10 tablet:h-[260px] tablet:w-[378px]'>
+                <Image
+                  className='mx-auto my-0 tablet:w-[300px]'
+                  src='/img_landing/img_bottom2.svg'
+                  alt='bottom image 1'
+                  width={260}
+                  height={107.35}
+                />
+              </div>
+              <div className='mx-auto my-0 flex h-[112.52px] w-[343px] flex-col justify-between rounded-b-lg bg-black-30 p-7 text-white tablet:h-[124px] tablet:w-[378px]'>
+                <h3 className='text-[18px] font-bold'>초대</h3>
+                <h4 className='text-[14px] font-medium'>
+                  새로운 팀원을 초대할 수 있어요.
+                </h4>
+              </div>
+            </div>
+
+            <div className='mb-[120px]'>
+              <div className='mx-auto my-0 flex h-[235.93px] w-[343px] justify-center rounded-t-lg bg-black-10 tablet:h-[260px] tablet:w-[378px]'>
+                <Image
+                  className='mx-auto my-0 tablet:w-[300px]'
+                  src='/img_landing/img_bottom3.svg'
+                  alt='bottom image 1'
+                  width={260}
+                  height={107.35}
+                />
+              </div>
+              <div className='mx-auto my-0 flex h-[112.52px] w-[343px] flex-col justify-between rounded-b-lg bg-black-30 p-7 text-white tablet:h-[124px] tablet:w-[378px]'>
+                <h3 className='text-[18px] font-bold'>구성원</h3>
+                <h4 className='text-[14px] font-medium'>
+                  구성원을 초대하고 내보낼 수 있어요.
+                </h4>
+              </div>
             </div>
           </div>
         </div>
       </div>
-
-      <div className='tablet:mx-[40px] tablet:flex tablet:justify-between desktop:mx-[141px]'>
-        <Link
-          href=''
-          className='mb-[12px] flex justify-center text-[12px] text-gray-40 tablet:text-[16px]'
-        >
-          ©codeit - 2023
-        </Link>
-        <div className='mx-auto mb-[68px] flex w-[117px] justify-between text-[12px] text-gray-40 tablet:mx-[0px] tablet:mb-[0px] tablet:w-[161px] tablet:text-[16px]'>
-          <Link href=''>Privacy Policy</Link>
-          <Link href=''>FAQ</Link>
-        </div>
-        <div className='mx-auto flex w-[93.27px] justify-between tablet:mx-[0px]'>
-          <Link href=''>
-            <Image
-              className='tablet:h-[20px] tablet:w-[20px]'
-              src='/icon/ic_message.svg'
-              alt='email icon'
-              width={18}
-              height={18}
-            />
-          </Link>
-          <Link href='https://www.facebook.com/?locale=ko_KR'>
-            <Image
-              className='tablet:h-[20px] tablet:w-[20px]'
-              src='/icon/ic_facebook.svg'
-              alt='facebook icon'
-              width={18}
-              height={18}
-            />
-          </Link>
-          <Link href='https://www.instagram.com/'>
-            <Image
-              className='tablet:h-[20px] tablet:w-[20px]'
-              src='/icon/ic_instagram.svg'
-              alt='instagram icon'
-              width={18}
-              height={18}
-            />
-          </Link>
-        </div>
-      </div>
-    </div>
+    </HomeLayout>
   );
 }

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -3,8 +3,13 @@ import DashboardLayout from "@/components/Layout/DashboardLayout";
 export default function MyDashBoard() {
   return (
     <>
-      <DashboardLayout>
-        <div></div>
+      <DashboardLayout
+        title='내 대시보드'
+        showActionButton={false}
+        showBadgeCounter={false}
+        showProfileDropdown={true}
+      >
+        <div>{/* MyDashboardPage의 콘텐츠 */}</div>
       </DashboardLayout>
     </>
   );

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -1,12 +1,11 @@
-import SideMenu from "@/components/SideMenu/SideMenu";
-import NavMyDashboard from "@/components/Navbar/NavMyDashboard";
+import DashboardLayout from "@/components/Layout/DashboardLayout";
 
 export default function MyDashBoard() {
   return (
     <>
-      <SideMenu/>
-      <NavMyDashboard />
-      my dashboard
+      <DashboardLayout>
+        <div></div>
+      </DashboardLayout>
     </>
   );
 }

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -7,6 +7,7 @@ const MyPage = () => {
       showActionButton={false}
       showBadgeCounter={false}
       showProfileDropdown={true}
+      fetchDashboardData={false}
     >
       <div>{/* MyPage의 콘텐츠 */}</div>
     </DashboardLayout>

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,4 +1,11 @@
+import DashboardLayout from "@/components/Layout/DashboardLayout";
+
 export default function MyPage() {
-  return <>
-  </>;
+  return (
+    <>
+      <DashboardLayout>
+        <div></div>
+      </DashboardLayout>
+    </>
+  );
 }

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,11 +1,16 @@
 import DashboardLayout from "@/components/Layout/DashboardLayout";
 
-export default function MyPage() {
+const MyPage = () => {
   return (
-    <>
-      <DashboardLayout>
-        <div></div>
-      </DashboardLayout>
-    </>
+    <DashboardLayout
+      title='계정관리'
+      showActionButton={false}
+      showBadgeCounter={false}
+      showProfileDropdown={true}
+    >
+      <div>{/* MyPage의 콘텐츠 */}</div>
+    </DashboardLayout>
   );
-}
+};
+
+export default MyPage;


### PR DESCRIPTION
💻 제목 - Feat: 페이지에 Layout 적용

## 🔎 작업 내용
- Nav height 문제 있어서 수정
- landing page 레이아웃 적용(Home Layout): nav + 본문 + footer
  - footer 컴포넌트 따로 분리
- Nav와 Sidemenu에 bg-white 추가 (Figma에 맞춰서)
- Dashboard Layout 컴포넌트 추가 및 dashboard 페이지마다 적용
- useAPI 개선: null 값 처리 로직 추가, 로그 추가, 에러 핸들링 개선
- dashboardid 페이지 동적 라우팅 적용 성공

## 📜 간단한 코드 설명 및 사용설명서
- 상기와 동일함

## 📷 결과물 (image , gif ..)
landing page(/):
![image](https://github.com/Team2-project/taskify/assets/162412765/2fe971fc-aa58-45bc-9001-9df4b01cc5ac)

/mypage:
![image](https://github.com/Team2-project/taskify/assets/162412765/634c3ebd-80d6-4c4e-891c-5a248d65dd7a)

/mydashboard:
![image](https://github.com/Team2-project/taskify/assets/162412765/7dce60c4-04ed-41ba-9b9d-d24f43b7cd7d)

/dashboard/{dashboardid}
![image](https://github.com/Team2-project/taskify/assets/162412765/3993be66-b005-4856-87a3-b7e8e9a489bf)

/dashboard/{dashboardid}/edit
![image](https://github.com/Team2-project/taskify/assets/162412765/acfd9a1d-4b59-4c8d-918c-f31a6705c550)


### 👀 공유포인트 및 이슈
- 현재 연결된 API는 dashboard의 title과, profile의 nickname밖에 없음.
- 로그인 후 token을 어떻게 연결해야하나 고민해 봐야함. 현재는 예시로 (진짜) 토큰을 넣어둠.

