### PR TITLE
Feat: My Page UI 완성

### DIFF
--- a/atoms/userAtom.ts
+++ b/atoms/userAtom.ts
@@ -1,0 +1,5 @@
+import { atom } from "jotai";
+import { User } from "@/lib/api/types/users";
+
+// User 데이터를 저장할 atom 생성
+export const userAtom = atom<User | null>(null);

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,7 +1,6 @@
 import { MouseEventHandler, ReactNode } from "react";
 
 type DefaultButtonProps = {
-  size?: "md" | "lg";
   children: ReactNode;
   disabled?: boolean;
   className?: string;
@@ -9,7 +8,6 @@ type DefaultButtonProps = {
 };
 
 export default function DefaultButton({
-  size,
   children = "",
   disabled = false,
   className = "",
@@ -18,21 +16,13 @@ export default function DefaultButton({
   const baseClasses =
     "border-box select-none rounded-[8px] bg-violet-20 text-[14px] font-medium text-white";
 
-  const sizeClasses = size
-    ? {
-        md: "w-max",
-        lg: "w-full",
-      }[size]
-    : "";
-
   return (
     <button
       disabled={disabled}
-      className={`${baseClasses} ${sizeClasses} ${className}`}
+      className={`${baseClasses} ${className}`}
       onClick={onClick}
     >
       {children}
     </button>
   );
 }
-

--- a/components/Form/FormField/FormField.tsx
+++ b/components/Form/FormField/FormField.tsx
@@ -24,6 +24,9 @@ interface FormFieldProps {
   placeholder?: string;
   error?: string;
   showError?: boolean;
+  width?: string;
+  tabletWidth?: string;
+  desktopWidth?: string;
 }
 
 const FormField = ({
@@ -35,6 +38,9 @@ const FormField = ({
   placeholder,
   error,
   showError = false,
+  width = "w-351",
+  tabletWidth = "tablet:w-520",
+  desktopWidth = "desktop:w-520",
 }: FormFieldProps) => {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -52,7 +58,7 @@ const FormField = ({
           value={value}
           onChange={onChange}
           placeholder={placeholder}
-          className={`h-50 w-351 rounded-lg border bg-white px-4 py-2 focus:outline-none tablet:w-520 ${
+          className={`h-50 ${width} ${tabletWidth} ${desktopWidth} rounded-lg border bg-white px-4 py-2 focus:outline-none ${
             showError && error
               ? "border-red"
               : "border-gray-30 focus:border-violet-20"

--- a/components/Form/FormField/FormField.tsx
+++ b/components/Form/FormField/FormField.tsx
@@ -68,7 +68,7 @@ const FormField = ({
             showError && error
               ? "border-red"
               : "border-gray-30 focus:border-violet-20"
-          }${readOnly || disabled ? "cursor-not-allowed bg-gray-20 text-gray-50" : ""}`}
+          }${readOnly || disabled ? "cursor-not-allowed bg-gray-30 text-gray-50" : ""}`}
         />
         {type === "password" && (
           <button

--- a/components/Form/FormField/FormField.tsx
+++ b/components/Form/FormField/FormField.tsx
@@ -25,6 +25,7 @@ interface FormFieldProps {
   error?: string;
   showError?: boolean;
   readOnly?: boolean;
+  disabled?: boolean;
   width?: string;
   tabletWidth?: string;
   desktopWidth?: string;
@@ -40,6 +41,7 @@ const FormField = ({
   error,
   showError = false,
   readOnly = false,
+  disabled = false,
   width = "w-351",
   tabletWidth = "tablet:w-520",
   desktopWidth = "desktop:w-520",
@@ -60,6 +62,7 @@ const FormField = ({
           value={value}
           onChange={onChange}
           readOnly={readOnly}
+          disabled={disabled}
           placeholder={placeholder}
           className={`h-50 ${width} ${tabletWidth} ${desktopWidth} rounded-lg border bg-white px-4 py-2 focus:outline-none ${
             showError && error

--- a/components/Form/FormField/FormField.tsx
+++ b/components/Form/FormField/FormField.tsx
@@ -20,10 +20,11 @@ interface FormFieldProps {
   type: string;
   name: string;
   value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder?: string;
   error?: string;
   showError?: boolean;
+  readOnly?: boolean;
   width?: string;
   tabletWidth?: string;
   desktopWidth?: string;
@@ -38,6 +39,7 @@ const FormField = ({
   placeholder,
   error,
   showError = false,
+  readOnly = false,
   width = "w-351",
   tabletWidth = "tablet:w-520",
   desktopWidth = "desktop:w-520",
@@ -57,12 +59,13 @@ const FormField = ({
           name={name}
           value={value}
           onChange={onChange}
+          readOnly={readOnly}
           placeholder={placeholder}
           className={`h-50 ${width} ${tabletWidth} ${desktopWidth} rounded-lg border bg-white px-4 py-2 focus:outline-none ${
             showError && error
               ? "border-red"
               : "border-gray-30 focus:border-violet-20"
-          }`}
+          }${readOnly ? "bg-gray-100 cursor-not-allowed" : ""}`}
         />
         {type === "password" && (
           <button

--- a/components/Form/FormField/FormField.tsx
+++ b/components/Form/FormField/FormField.tsx
@@ -68,7 +68,7 @@ const FormField = ({
             showError && error
               ? "border-red"
               : "border-gray-30 focus:border-violet-20"
-          }${readOnly ? "bg-gray-100 cursor-not-allowed" : ""}`}
+          }${readOnly || disabled ? "cursor-not-allowed bg-gray-20 text-gray-50" : ""}`}
         />
         {type === "password" && (
           <button

--- a/components/ImageUploader/index.tsx
+++ b/components/ImageUploader/index.tsx
@@ -1,0 +1,66 @@
+/*
+이미지를 업로드하는 기능이 있는 컴포넌트
+계정관리(MyPage) 와 할일생성Modal 에서 사용
+*/
+
+import React, { useRef } from "react";
+import ResponsiveImage from "../ResponsiveImage";
+
+interface ImageUploaderProps {
+  profileImage: string | ArrayBuffer | null;
+  onImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  mobileWidth: string;
+  tabletWidth: string;
+  desktopWidth: string;
+  mobileHeight: string;
+  tabletHeight: string;
+  desktopHeight: string;
+}
+
+const ImageUploader: React.FC<ImageUploaderProps> = ({
+  profileImage,
+  onImageChange,
+  mobileWidth,
+  tabletWidth,
+  desktopWidth,
+  mobileHeight,
+  tabletHeight,
+  desktopHeight,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div
+      className={`flex cursor-pointer items-center justify-center rounded-[6px] border border-gray bg-gray ${mobileHeight} ${mobileWidth} tablet:${tabletHeight} tablet:${tabletWidth} desktop:${desktopHeight} desktop:${desktopWidth}`}
+      onClick={handleImageClick}
+    >
+      {profileImage ? (
+        <img
+          src={profileImage as string}
+          alt='미리보기'
+          className='h-full w-full rounded-[6px] object-cover'
+        />
+      ) : (
+        <ResponsiveImage
+          src='/icon/ic_add_profile.png'
+          alt='사진 추가'
+          mobile={{ width: 20, height: 20 }}
+          tablet={{ width: 30, height: 30 }}
+          desktop={{ width: 30, height: 30 }}
+        />
+      )}
+      <input
+        type='file'
+        ref={fileInputRef}
+        className='hidden'
+        onChange={onImageChange}
+      />
+    </div>
+  );
+};
+
+export default ImageUploader;

--- a/components/ImageUploader/index.tsx
+++ b/components/ImageUploader/index.tsx
@@ -35,7 +35,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
 
   return (
     <div
-      className={`flex cursor-pointer items-center justify-center rounded-[6px] border border-gray bg-gray ${mobileHeight} ${mobileWidth} tablet:${tabletHeight} tablet:${tabletWidth} desktop:${desktopHeight} desktop:${desktopWidth}`}
+      className={`flex cursor-pointer items-center justify-center rounded-[6px] border border-gray bg-gray ${mobileHeight} ${mobileWidth} ${tabletHeight} ${tabletWidth} ${desktopHeight} ${desktopWidth}`}
       onClick={handleImageClick}
     >
       {profileImage ? (

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -31,7 +31,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({
   showCreatedByMeIcon = true,
 }) => {
   const token =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NDE0NDM0LCJpc3MiOiJzcC10YXNraWZ5In0.JRAWWvLmLkWJQRHJPX1ii6RrW7W8Q9tyRk5ENeFUz5A";
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDAyNywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5NjM2ODk2LCJpc3MiOiJzcC10YXNraWZ5In0.6U-hTgLC-PGnoZle_0bOcDA6h4LEgw3QnsXcQyMJLr0";
 
   const userConfig: AxiosRequestConfig = {
     url: "/users/me",
@@ -111,7 +111,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({
           <div className='flex-shrink-0'>
             <SideMenu />
           </div>
-          <div className='ml-[300px] flex-1 p-4 max-desktop:ml-[160px] max-tablet:ml-[67px]'>
+          <div className='ml-[300px] flex-1 overflow-auto p-4 max-desktop:ml-[160px] max-tablet:ml-[67px]'>
             {children}
           </div>
         </div>

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -2,13 +2,15 @@
 DashboardLayout: MyPage, Dashboard, MyDashboard에 적용하는 Layout
 */
 
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useEffect } from "react";
+import { useAtom } from "jotai";
 import NavMyDashboard from "@/components/Navbar/NavMyDashboard";
 import SideMenu from "@/components/SideMenu/SideMenu";
 import fetcher from "@/lib/api/fetcher";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosRequestConfig } from "axios";
 import { User } from "@/lib/api/types/users";
+import { userAtom } from "@/atoms/userAtom";
 import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 
 interface DashboardLayoutProps {
@@ -48,6 +50,8 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({
       Authorization: `Bearer ${token}`,
     },
   };
+  // Jotai의 useAtom 훅을 사용하여 userData를 atom에 저장
+  const [, setUserData] = useAtom(userAtom);
 
   const {
     data: userData,
@@ -57,6 +61,13 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({
     queryKey: ["userData"],
     queryFn: () => fetcher<User>(userConfig),
   });
+
+  // userData가 업데이트될 때마다 setUserData를 호출
+  useEffect(() => {
+    if (userData) {
+      setUserData(userData);
+    }
+  }, [userData, setUserData]);
 
   const {
     data: dashboardData,

--- a/components/MyPage/BackLink.tsx
+++ b/components/MyPage/BackLink.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from "react";
+import Link from "next/link";
+import ResponsiveImage from "@/components/ResponsiveImage";
+
+interface BackLinkProps {
+  href: string;
+  label: string;
+}
+
+const BackLink: FC<BackLinkProps> = ({ href, label }) => {
+  return (
+    <Link href={href}>
+      <div className='mb-[20px] flex items-center justify-start tablet:mb-[25px] desktop:mb-[25px]'>
+        <div className='flex-shrink-0'>
+          <ResponsiveImage
+            src='/icon/ic_arrow_back.svg'
+            alt='뒤로가기'
+            mobile={{ width: 18, height: 18 }}
+            tablet={{ width: 20, height: 20 }}
+            desktop={{ width: 20, height: 20 }}
+          />
+        </div>
+        <span className='ml-[6px] text-[14px] font-medium tablet:text-[16px] desktop:text-[16px]'>
+          {label}
+        </span>
+      </div>
+    </Link>
+  );
+};
+
+export default BackLink;

--- a/components/MyPage/PasswordChange.tsx
+++ b/components/MyPage/PasswordChange.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from "react";
+import { atom, useAtom } from "jotai";
+import Form from "@/components/Form/FormField/FormField";
+import DefaultButton from "@/components/Button";
+import { validatePassword } from "@/lib/validation";
+
+// Jotai를 사용한 상태 관리
+const currentPasswordAtom = atom("");
+const newPasswordAtom = atom("");
+const confirmPasswordAtom = atom("");
+const currentPasswordErrorAtom = atom("");
+const newPasswordErrorAtom = atom("");
+const confirmPasswordErrorAtom = atom("");
+const isPasswordFormValidAtom = atom(false);
+
+const PasswordChange: React.FC = () => {
+  const [currentPassword, setCurrentPassword] = useAtom(currentPasswordAtom);
+  const [newPassword, setNewPassword] = useAtom(newPasswordAtom);
+  const [confirmPassword, setConfirmPassword] = useAtom(confirmPasswordAtom);
+  const [currentPasswordError, setCurrentPasswordError] = useAtom(
+    currentPasswordErrorAtom,
+  );
+  const [newPasswordError, setNewPasswordError] = useAtom(newPasswordErrorAtom);
+  const [confirmPasswordError, setConfirmPasswordError] = useAtom(
+    confirmPasswordErrorAtom,
+  );
+  const [isPasswordFormValid, setIsPasswordFormValid] = useAtom(
+    isPasswordFormValidAtom,
+  );
+
+  // useState를 사용한 입력 여부 상태 관리
+  const [currentPasswordTouched, setCurrentPasswordTouched] =
+    useState<boolean>(false);
+  const [newPasswordTouched, setNewPasswordTouched] = useState<boolean>(false);
+  const [confirmPasswordTouched, setConfirmPasswordTouched] =
+    useState<boolean>(false);
+
+  // 비밀번호 변경 Form 유효성 검사
+  useEffect(() => {
+    setCurrentPasswordError(validatePassword(currentPassword));
+    setNewPasswordError(validatePassword(newPassword));
+    setConfirmPasswordError(
+      newPassword !== confirmPassword ? "새 비밀번호가 일치하지 않습니다." : "",
+    );
+    setIsPasswordFormValid(
+      !validatePassword(currentPassword) &&
+        !validatePassword(newPassword) &&
+        newPassword === confirmPassword,
+    );
+  }, [
+    currentPassword,
+    newPassword,
+    confirmPassword,
+    setCurrentPasswordError,
+    setNewPasswordError,
+    setConfirmPasswordError,
+    setIsPasswordFormValid,
+  ]);
+
+  // 비밀번호 변경 Form 제출 처리 함수
+  const handlePasswordChangeSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!isPasswordFormValid) return;
+    console.log("비밀번호 변경:", { currentPassword, newPassword });
+  };
+
+  return (
+    <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
+      <div className='mb-[24px] text-[20px] font-bold tablet:mb-[32px] tablet:text-[24px] desktop:text-[24px]'>
+        비밀번호 변경
+      </div>
+      <Form onSubmit={handlePasswordChangeSubmit}>
+        <Form.Field
+          label='현재 비밀번호'
+          type='password'
+          name='currentPassword'
+          value={currentPassword}
+          onChange={(e) => {
+            setCurrentPassword(e.target.value);
+            setCurrentPasswordTouched(true);
+          }}
+          placeholder='현재 비밀번호 입력'
+          error={currentPasswordError}
+          showError={currentPasswordTouched && !!currentPasswordError}
+          width='w-244'
+          tabletWidth='tablet:w-488'
+          desktopWidth='desktop:w-564'
+        />
+        <Form.Field
+          label='새 비밀번호'
+          type='password'
+          name='newPassword'
+          value={newPassword}
+          onChange={(e) => {
+            setNewPassword(e.target.value);
+            setNewPasswordTouched(true);
+          }}
+          placeholder='새 비밀번호 입력'
+          error={newPasswordError}
+          showError={newPasswordTouched && !!newPasswordError}
+          width='w-244'
+          tabletWidth='tablet:w-488'
+          desktopWidth='desktop:w-564'
+        />
+        <Form.Field
+          label='새 비밀번호 확인'
+          type='password'
+          name='confirmPassword'
+          value={confirmPassword}
+          onChange={(e) => {
+            setConfirmPassword(e.target.value);
+            setConfirmPasswordTouched(true);
+          }}
+          placeholder='새 비밀번호 다시 입력 '
+          error={confirmPasswordError}
+          showError={confirmPasswordTouched && !!confirmPasswordError}
+          width='w-244'
+          tabletWidth='tablet:w-488'
+          desktopWidth='desktop:w-564'
+        />
+        <div className='mb-[20px] mt-[16px] flex justify-end tablet:mb-[28px] tablet:mt-[24px] desktop:mt-[24px]'>
+          <DefaultButton
+            size='lg'
+            disabled={!isPasswordFormValid}
+            className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
+          >
+            변경
+          </DefaultButton>
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+export default PasswordChange;

--- a/components/MyPage/PasswordChange.tsx
+++ b/components/MyPage/PasswordChange.tsx
@@ -120,7 +120,6 @@ const PasswordChange: React.FC = () => {
         />
         <div className='mb-[20px] mt-[16px] flex justify-end tablet:mb-[28px] tablet:mt-[24px] desktop:mt-[24px]'>
           <DefaultButton
-            size='lg'
             disabled={!isPasswordFormValid}
             className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
           >

--- a/components/MyPage/ProfileUpdate.tsx
+++ b/components/MyPage/ProfileUpdate.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { FC, useState, useEffect } from "react";
 import { atom, useAtom } from "jotai";
 import ResponsiveImage from "@/components/ResponsiveImage";
 import Form from "@/components/Form/FormField/FormField";
 import DefaultButton from "@/components/Button";
 import { validateNickname } from "@/lib/validation";
+import { userAtom } from "@/atoms/userAtom";
 
 // Jotai를 사용한 상태 관리
 const nicknameAtom = atom("");
@@ -14,12 +15,13 @@ interface ProfileUpdateProps {
   email: string;
 }
 
-const ProfileUpdate: React.FC<ProfileUpdateProps> = ({ email }) => {
+const ProfileUpdate: FC = () => {
   const [nickname, setNickname] = useAtom(nicknameAtom);
   const [nicknameError, setNicknameError] = useAtom(nicknameErrorAtom);
   const [isProfileFormValid, setIsProfileFormValid] = useAtom(
     isProfileFormValidAtom,
   );
+  const [userData] = useAtom(userAtom);
 
   // useState를 사용한 입력 여부 상태 관리
   const [nicknameTouched, setNicknameTouched] = useState<boolean>(false);
@@ -34,7 +36,7 @@ const ProfileUpdate: React.FC<ProfileUpdateProps> = ({ email }) => {
   const handleProfileSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isProfileFormValid) return;
-    console.log("프로필 업데이트:", { email, nickname });
+    console.log("프로필 업데이트:", { email: userData?.email, nickname });
   };
 
   return (
@@ -58,7 +60,7 @@ const ProfileUpdate: React.FC<ProfileUpdateProps> = ({ email }) => {
               label='이메일'
               type='email'
               name='profileEmail'
-              value={email}
+              value={userData?.email || ""}
               disabled
               placeholder='내 이메일'
               width='w-244'

--- a/components/MyPage/ProfileUpdate.tsx
+++ b/components/MyPage/ProfileUpdate.tsx
@@ -109,7 +109,6 @@ const ProfileUpdate: FC = () => {
         </div>
         <div className='mb-[20px] mt-[16px] flex justify-end tablet:mb-[28px] tablet:mt-[24px] desktop:mt-[24px]'>
           <DefaultButton
-            size='lg'
             disabled={!isProfileFormValid}
             className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
           >

--- a/components/MyPage/ProfileUpdate.tsx
+++ b/components/MyPage/ProfileUpdate.tsx
@@ -3,51 +3,38 @@ import { atom, useAtom } from "jotai";
 import ResponsiveImage from "@/components/ResponsiveImage";
 import Form from "@/components/Form/FormField/FormField";
 import DefaultButton from "@/components/Button";
-import { validateEmail, validateNickname } from "@/lib/validation";
+import { validateNickname } from "@/lib/validation";
 
 // Jotai를 사용한 상태 관리
-const profileEmailAtom = atom("");
 const nicknameAtom = atom("");
-const profileEmailErrorAtom = atom("");
 const nicknameErrorAtom = atom("");
 const isProfileFormValidAtom = atom(false);
 
-const ProfileUpdate: React.FC = () => {
-  const [profileEmail, setProfileEmail] = useAtom(profileEmailAtom);
+interface ProfileUpdateProps {
+  email: string;
+}
+
+const ProfileUpdate: React.FC<ProfileUpdateProps> = ({ email }) => {
   const [nickname, setNickname] = useAtom(nicknameAtom);
-  const [profileEmailError, setProfileEmailError] = useAtom(
-    profileEmailErrorAtom,
-  );
   const [nicknameError, setNicknameError] = useAtom(nicknameErrorAtom);
   const [isProfileFormValid, setIsProfileFormValid] = useAtom(
     isProfileFormValidAtom,
   );
 
   // useState를 사용한 입력 여부 상태 관리
-  const [profileEmailTouched, setProfileEmailTouched] =
-    useState<boolean>(false);
   const [nicknameTouched, setNicknameTouched] = useState<boolean>(false);
 
   // 프로필 Form 유효성 검사
   useEffect(() => {
-    setProfileEmailError(validateEmail(profileEmail));
     setNicknameError(validateNickname(nickname));
-    setIsProfileFormValid(
-      !validateEmail(profileEmail) && !validateNickname(nickname),
-    );
-  }, [
-    profileEmail,
-    nickname,
-    setProfileEmailError,
-    setNicknameError,
-    setIsProfileFormValid,
-  ]);
+    setIsProfileFormValid(!validateNickname(nickname));
+  }, [nickname, setNicknameError, setIsProfileFormValid]);
 
   // 프로필 Form 제출 처리 함수
   const handleProfileSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isProfileFormValid) return;
-    console.log("프로필 업데이트:", { profileEmail, nickname });
+    console.log("프로필 업데이트:", { email, nickname });
   };
 
   return (
@@ -71,14 +58,9 @@ const ProfileUpdate: React.FC = () => {
               label='이메일'
               type='email'
               name='profileEmail'
-              value={profileEmail}
-              onChange={(e) => {
-                setProfileEmail(e.target.value);
-                setProfileEmailTouched(true);
-              }}
-              placeholder='이메일 입력'
-              error={profileEmailError}
-              showError={profileEmailTouched && !!profileEmailError}
+              value={email}
+              disabled
+              placeholder='내 이메일'
               width='w-244'
               tabletWidth='tablet:w-290'
               desktopWidth='desktop:w-366'

--- a/components/MyPage/ProfileUpdate.tsx
+++ b/components/MyPage/ProfileUpdate.tsx
@@ -5,6 +5,7 @@ import Form from "@/components/Form/FormField/FormField";
 import DefaultButton from "@/components/Button";
 import { validateNickname } from "@/lib/validation";
 import { userAtom } from "@/atoms/userAtom";
+import ImageUploader from "@/components/ImageUploader";
 
 // Jotai를 사용한 상태 관리
 const nicknameErrorAtom = atom("");
@@ -18,8 +19,9 @@ const ProfileUpdate: FC = () => {
   );
 
   // 프로필 이미지 상태 관리
-  const [profileImage, setProfileImage] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [profileImage, setProfileImage] = useState<string | ArrayBuffer | null>(
+    userData?.profileImageUrl || null,
+  );
 
   // useState를 사용한 입력 여부 상태 관리
   const [nicknameTouched, setNicknameTouched] = useState<boolean>(false);
@@ -47,16 +49,15 @@ const ProfileUpdate: FC = () => {
   };
 
   //프로필 이미지 업로드 관련
-  const handleImageClick = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setProfileImage(reader.result as string);
+        setProfileImage(reader.result);
+        setUserData((prev) =>
+          prev ? { ...prev, profileImageUrl: reader.result as string } : prev,
+        );
       };
       reader.readAsDataURL(file);
     }
@@ -69,31 +70,15 @@ const ProfileUpdate: FC = () => {
       </div>
       <Form onSubmit={handleProfileSubmit}>
         <div className='flex flex-col gap-4 tablet:flex-row tablet:items-center'>
-          <div
-            className='flex h-[100px] w-[100px] cursor-pointer items-center justify-center rounded-[6px] border border-gray bg-gray tablet:h-[182px] tablet:w-[182px] desktop:h-[182px] desktop:w-[182px]'
-            onClick={handleImageClick}
-          >
-            {profileImage ? (
-              <img
-                src={profileImage}
-                alt='프로필 미리보기'
-                className='h-full w-full rounded-[6px] object-cover'
-              />
-            ) : (
-              <ResponsiveImage
-                src='/icon/ic_add_profile.png'
-                alt='프로필 사진 추가'
-                mobile={{ width: 20, height: 20 }}
-                tablet={{ width: 30, height: 30 }}
-                desktop={{ width: 30, height: 30 }}
-              />
-            )}
-          </div>
-          <input
-            type='file'
-            ref={fileInputRef}
-            className='hidden'
-            onChange={handleFileChange}
+          <ImageUploader
+            profileImage={profileImage}
+            onImageChange={handleImageChange}
+            mobileHeight='h-[100px]'
+            tabletHeight='h-[182px]'
+            desktopHeight='h-[182px]'
+            mobileWidth='w-[100px]'
+            tabletWidth='w-[182px]'
+            desktopWidth='w-[182px]'
           />
           <div className='flex flex-col gap-4'>
             <Form.Field

--- a/components/MyPage/ProfileUpdate.tsx
+++ b/components/MyPage/ProfileUpdate.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from "react";
+import { atom, useAtom } from "jotai";
+import ResponsiveImage from "@/components/ResponsiveImage";
+import Form from "@/components/Form/FormField/FormField";
+import DefaultButton from "@/components/Button";
+import { validateEmail, validateNickname } from "@/lib/validation";
+
+// Jotai를 사용한 상태 관리
+const profileEmailAtom = atom("");
+const nicknameAtom = atom("");
+const profileEmailErrorAtom = atom("");
+const nicknameErrorAtom = atom("");
+const isProfileFormValidAtom = atom(false);
+
+const ProfileUpdate: React.FC = () => {
+  const [profileEmail, setProfileEmail] = useAtom(profileEmailAtom);
+  const [nickname, setNickname] = useAtom(nicknameAtom);
+  const [profileEmailError, setProfileEmailError] = useAtom(
+    profileEmailErrorAtom,
+  );
+  const [nicknameError, setNicknameError] = useAtom(nicknameErrorAtom);
+  const [isProfileFormValid, setIsProfileFormValid] = useAtom(
+    isProfileFormValidAtom,
+  );
+
+  // useState를 사용한 입력 여부 상태 관리
+  const [profileEmailTouched, setProfileEmailTouched] =
+    useState<boolean>(false);
+  const [nicknameTouched, setNicknameTouched] = useState<boolean>(false);
+
+  // 프로필 Form 유효성 검사
+  useEffect(() => {
+    setProfileEmailError(validateEmail(profileEmail));
+    setNicknameError(validateNickname(nickname));
+    setIsProfileFormValid(
+      !validateEmail(profileEmail) && !validateNickname(nickname),
+    );
+  }, [
+    profileEmail,
+    nickname,
+    setProfileEmailError,
+    setNicknameError,
+    setIsProfileFormValid,
+  ]);
+
+  // 프로필 Form 제출 처리 함수
+  const handleProfileSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!isProfileFormValid) return;
+    console.log("프로필 업데이트:", { profileEmail, nickname });
+  };
+
+  return (
+    <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
+      <div className='mb-[24px] text-[20px] font-bold tablet:mb-[32px] tablet:text-[24px] desktop:mb-[32px] desktop:text-[24px]'>
+        프로필
+      </div>
+      <Form onSubmit={handleProfileSubmit}>
+        <div className='flex flex-col gap-4 tablet:flex-row tablet:items-center'>
+          <div className='flex h-[100px] w-[100px] items-center rounded-[6px] border border-gray bg-gray tablet:h-[182px] tablet:w-[182px] desktop:h-[182px] desktop:w-[182px]'>
+            <ResponsiveImage
+              src='/icon/ic_add_profile.png'
+              alt='프로필 사진 추가'
+              mobile={{ width: 20, height: 20 }}
+              tablet={{ width: 30, height: 30 }}
+              desktop={{ width: 30, height: 30 }}
+            />
+          </div>
+          <div className='flex flex-col gap-4'>
+            <Form.Field
+              label='이메일'
+              type='email'
+              name='profileEmail'
+              value={profileEmail}
+              onChange={(e) => {
+                setProfileEmail(e.target.value);
+                setProfileEmailTouched(true);
+              }}
+              placeholder='이메일 입력'
+              error={profileEmailError}
+              showError={profileEmailTouched && !!profileEmailError}
+              width='w-244'
+              tabletWidth='tablet:w-290'
+              desktopWidth='desktop:w-366'
+            />
+            <Form.Field
+              label='닉네임'
+              type='text'
+              name='nickname'
+              value={nickname}
+              onChange={(e) => {
+                setNickname(e.target.value);
+                setNicknameTouched(true);
+              }}
+              placeholder='닉네임 입력'
+              error={nicknameError}
+              showError={nicknameTouched && !!nicknameError}
+              width='w-244'
+              tabletWidth='tablet:w-290'
+              desktopWidth='desktop:w-366'
+            />
+          </div>
+        </div>
+        <div className='mb-[20px] mt-[16px] flex justify-end tablet:mb-[28px] tablet:mt-[24px] desktop:mt-[24px]'>
+          <DefaultButton
+            size='lg'
+            disabled={!isProfileFormValid}
+            className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
+          >
+            저장
+          </DefaultButton>
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+export default ProfileUpdate;

--- a/components/MyPage/ProfileUpdate.tsx
+++ b/components/MyPage/ProfileUpdate.tsx
@@ -74,11 +74,11 @@ const ProfileUpdate: FC = () => {
             profileImage={profileImage}
             onImageChange={handleImageChange}
             mobileHeight='h-[100px]'
-            tabletHeight='h-[182px]'
-            desktopHeight='h-[182px]'
             mobileWidth='w-[100px]'
-            tabletWidth='w-[182px]'
-            desktopWidth='w-[182px]'
+            tabletHeight='tablet:h-[182px]'
+            tabletWidth='tablet:w-[182px]'
+            desktopHeight='desktop:h-[182px]'
+            desktopWidth='desktop:w-[182px]'
           />
           <div className='flex flex-col gap-4'>
             <Form.Field

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -10,7 +10,7 @@ import {
   validatePassword,
 } from "@/lib/validation";
 
-const MyPage = () => {
+const MyPage: FC = () => {
   // 프로필 Form 상태 변수
   const [profileEmail, setProfileEmail] = useState<string>("");
   const [nickname, setNickname] = useState<string>("");
@@ -90,10 +90,10 @@ const MyPage = () => {
       showCreatedByMeIcon={false}
     >
       {/* 돌아가기 링크 */}
-      <div className='flex items-center justify-start'>
+      <div className='mb-[20px] flex items-center justify-start tablet:mb-[25px] desktop:mb-[25px]'>
         <div className='flex-shrink-0'>
           <ResponsiveImage
-            src='/icon/ic_arrow_forward.svg'
+            src='/icon/ic_arrow_back.svg'
             alt='뒤로가기'
             mobile={{ width: 18, height: 18 }}
             tablet={{ width: 20, height: 20 }}
@@ -107,7 +107,7 @@ const MyPage = () => {
 
       {/* 프로필 폼 */}
       <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
-        <div className='text-[20px] font-bold tablet:text-[24px] desktop:text-[24px]'>
+        <div className='mb-[24px] text-[20px] font-bold tablet:mb-[32px] tablet:text-[24px] desktop:mb-[32px] desktop:text-[24px]'>
           프로필
         </div>
         <Form onSubmit={handleProfileSubmit}>
@@ -131,7 +131,7 @@ const MyPage = () => {
                   setProfileEmail(e.target.value);
                   setProfileEmailTouched(true);
                 }}
-                placeholder='이메일을 입력해 주세요'
+                placeholder='이메일 입력'
                 error={profileEmailError}
                 showError={profileEmailTouched && !!profileEmailError}
                 width='w-244'
@@ -147,7 +147,7 @@ const MyPage = () => {
                   setNickname(e.target.value);
                   setNicknameTouched(true);
                 }}
-                placeholder='닉네임을 입력해 주세요'
+                placeholder='닉네임 입력'
                 error={nicknameError}
                 showError={nicknameTouched && !!nicknameError}
                 width='w-244'
@@ -156,7 +156,7 @@ const MyPage = () => {
               />
             </div>
           </div>
-          <div className='flex justify-end'>
+          <div className='mt-[16px] flex justify-end tablet:mt-[24px] desktop:mt-[24px]'>
             <DefaultButton
               size='lg'
               disabled={!isProfileFormValid}
@@ -171,7 +171,7 @@ const MyPage = () => {
 
       {/* 비밀번호 변경 폼 */}
       <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
-        <div className='text-[20px] font-bold tablet:text-[24px] desktop:text-[24px]'>
+        <div className='mb-[24px] text-[20px] font-bold tablet:mb-[32px] tablet:text-[24px] desktop:text-[24px]'>
           비밀번호 변경
         </div>
         <Form onSubmit={handlePasswordChangeSubmit}>
@@ -184,7 +184,7 @@ const MyPage = () => {
               setCurrentPassword(e.target.value);
               setCurrentPasswordTouched(true);
             }}
-            placeholder='현재 비밀번호를 입력해 주세요'
+            placeholder='현재 비밀번호 입력'
             error={currentPasswordError}
             showError={currentPasswordTouched && !!currentPasswordError}
             width='w-244'
@@ -200,7 +200,7 @@ const MyPage = () => {
               setNewPassword(e.target.value);
               setNewPasswordTouched(true);
             }}
-            placeholder='새 비밀번호를 입력해 주세요'
+            placeholder='새 비밀번호 입력'
             error={newPasswordError}
             showError={confirmPasswordTouched && !!confirmPasswordError}
             width='w-244'
@@ -216,14 +216,14 @@ const MyPage = () => {
               setConfirmPassword(e.target.value);
               setConfirmPasswordTouched(true);
             }}
-            placeholder='새 비밀번호를 다시 입력해 주세요'
+            placeholder='새 비밀번호 다시 입력 '
             error={confirmPasswordError}
             showError={confirmPasswordTouched && !!confirmPasswordError}
             width='w-244'
             tabletWidth='tablet:w-488'
             desktopWidth='desktop:w-564'
           />
-          <div className='flex justify-end'>
+          <div className='mt-[16px] flex justify-end tablet:mt-[24px] desktop:mt-[24px]'>
             <DefaultButton
               size='lg'
               disabled={!isPasswordFormValid}

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -27,6 +27,16 @@ const MyPage = () => {
   const [newPasswordError, setNewPasswordError] = useState<string>("");
   const [confirmPasswordError, setConfirmPasswordError] = useState<string>("");
 
+  // 필드에 입력 여부 상태 변수
+  const [profileEmailTouched, setProfileEmailTouched] =
+    useState<boolean>(false);
+  const [nicknameTouched, setNicknameTouched] = useState<boolean>(false);
+  const [currentPasswordTouched, setCurrentPasswordTouched] =
+    useState<boolean>(false);
+  const [newPasswordTouched, setNewPasswordTouched] = useState<boolean>(false);
+  const [confirmPasswordTouched, setConfirmPasswordTouched] =
+    useState<boolean>(false);
+
   // Form 유효성 상태 변수
   const [isProfileFormValid, setIsProfileFormValid] = useState<boolean>(false);
   const [isPasswordFormValid, setIsPasswordFormValid] =
@@ -117,10 +127,13 @@ const MyPage = () => {
                 type='email'
                 name='profileEmail'
                 value={profileEmail}
-                onChange={(e) => setProfileEmail(e.target.value)}
+                onChange={(e) => {
+                  setProfileEmail(e.target.value);
+                  setProfileEmailTouched(true);
+                }}
                 placeholder='이메일을 입력해 주세요'
                 error={profileEmailError}
-                showError={!!profileEmailError}
+                showError={profileEmailTouched && !!profileEmailError}
                 width='w-244'
                 tabletWidth='tablet:w-290'
                 desktopWidth='desktop:w-366'
@@ -130,10 +143,13 @@ const MyPage = () => {
                 type='text'
                 name='nickname'
                 value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
+                onChange={(e) => {
+                  setNickname(e.target.value);
+                  setNicknameTouched(true);
+                }}
                 placeholder='닉네임을 입력해 주세요'
                 error={nicknameError}
-                showError={!!nicknameError}
+                showError={nicknameTouched && !!nicknameError}
                 width='w-244'
                 tabletWidth='tablet:w-290'
                 desktopWidth='desktop:w-366'
@@ -164,10 +180,13 @@ const MyPage = () => {
             type='password'
             name='currentPassword'
             value={currentPassword}
-            onChange={(e) => setCurrentPassword(e.target.value)}
+            onChange={(e) => {
+              setCurrentPassword(e.target.value);
+              setCurrentPasswordTouched(true);
+            }}
             placeholder='현재 비밀번호를 입력해 주세요'
             error={currentPasswordError}
-            showError={!!currentPasswordError}
+            showError={currentPasswordTouched && !!currentPasswordError}
             width='w-244'
             tabletWidth='tablet:w-488'
             desktopWidth='desktop:w-564'
@@ -177,10 +196,13 @@ const MyPage = () => {
             type='password'
             name='newPassword'
             value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              setNewPasswordTouched(true);
+            }}
             placeholder='새 비밀번호를 입력해 주세요'
             error={newPasswordError}
-            showError={!!newPasswordError}
+            showError={confirmPasswordTouched && !!confirmPasswordError}
             width='w-244'
             tabletWidth='tablet:w-488'
             desktopWidth='desktop:w-564'
@@ -190,10 +212,13 @@ const MyPage = () => {
             type='password'
             name='confirmPassword'
             value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
+            onChange={(e) => {
+              setConfirmPassword(e.target.value);
+              setConfirmPasswordTouched(true);
+            }}
             placeholder='새 비밀번호를 다시 입력해 주세요'
             error={confirmPasswordError}
-            showError={!!confirmPasswordError}
+            showError={confirmPasswordTouched && !!confirmPasswordError}
             width='w-244'
             tabletWidth='tablet:w-488'
             desktopWidth='desktop:w-564'

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,86 +1,13 @@
-import React, { useState, useEffect } from "react";
-import { FC } from "react";
+/*
+  MyPage(계정관리)
+*/
+import React, { FC } from "react";
 import DashboardLayout from "@/components/Layout/DashboardLayout";
-import ResponsiveImage from "@/components/ResponsiveImage";
-import Form from "@/components/Form/FormField/FormField";
-import DefaultButton from "@/components/Button";
-import {
-  validateEmail,
-  validateNickname,
-  validatePassword,
-} from "@/lib/validation";
+import ProfileUpdate from "@/components/MyPage/ProfileUpdate";
+import PasswordChange from "@/components/MyPage/PasswordChange";
+import BackLink from "@/components/MyPage/BackLink";
 
 const MyPage: FC = () => {
-  // 프로필 Form 상태 변수
-  const [profileEmail, setProfileEmail] = useState<string>("");
-  const [nickname, setNickname] = useState<string>("");
-
-  // 비밀번호 변경 Form 상태 변수
-  const [currentPassword, setCurrentPassword] = useState<string>("");
-  const [newPassword, setNewPassword] = useState<string>("");
-  const [confirmPassword, setConfirmPassword] = useState<string>("");
-
-  // 오류 상태 변수
-  const [profileEmailError, setProfileEmailError] = useState<string>("");
-  const [nicknameError, setNicknameError] = useState<string>("");
-  const [currentPasswordError, setCurrentPasswordError] = useState<string>("");
-  const [newPasswordError, setNewPasswordError] = useState<string>("");
-  const [confirmPasswordError, setConfirmPasswordError] = useState<string>("");
-
-  // 필드에 입력 여부 상태 변수
-  const [profileEmailTouched, setProfileEmailTouched] =
-    useState<boolean>(false);
-  const [nicknameTouched, setNicknameTouched] = useState<boolean>(false);
-  const [currentPasswordTouched, setCurrentPasswordTouched] =
-    useState<boolean>(false);
-  const [newPasswordTouched, setNewPasswordTouched] = useState<boolean>(false);
-  const [confirmPasswordTouched, setConfirmPasswordTouched] =
-    useState<boolean>(false);
-
-  // Form 유효성 상태 변수
-  const [isProfileFormValid, setIsProfileFormValid] = useState<boolean>(false);
-  const [isPasswordFormValid, setIsPasswordFormValid] =
-    useState<boolean>(false);
-
-  //프로필 Form 유효성 검사
-  useEffect(() => {
-    setProfileEmailError(validateEmail(profileEmail));
-    setNicknameError(validateNickname(nickname));
-    setIsProfileFormValid(
-      !validateEmail(profileEmail) && !validateNickname(nickname),
-    );
-  }, [profileEmail, nickname]);
-
-  //비밀번호 변경 Form 유효성 검사
-  useEffect(() => {
-    setCurrentPasswordError(validatePassword(currentPassword));
-    setNewPasswordError(validatePassword(newPassword));
-    setConfirmPasswordError(
-      newPassword !== confirmPassword ? "새 비밀번호가 일치하지 않습니다." : "",
-    );
-    setIsPasswordFormValid(
-      !validatePassword(currentPassword) &&
-        !validatePassword(newPassword) &&
-        newPassword === confirmPassword,
-    );
-  }, [currentPassword, newPassword, confirmPassword]);
-
-  // 프로필 Form 제출 처리 함수
-  const handleProfileSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!isProfileFormValid) return;
-    // Validation and API call logic for profile update
-    console.log("프로필 업데이트:", { profileEmail, nickname });
-  };
-
-  // 비밀번호 변경 Form 제출 처리 함수
-  const handlePasswordChangeSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!isPasswordFormValid) return;
-    // 비밀번호 변경 로직
-    console.log("비밀번호 변경:", { currentPassword, newPassword });
-  };
-
   return (
     <DashboardLayout
       title='계정관리'
@@ -90,150 +17,15 @@ const MyPage: FC = () => {
       showCreatedByMeIcon={false}
     >
       {/* 돌아가기 링크 */}
-      <div className='mb-[20px] flex items-center justify-start tablet:mb-[25px] desktop:mb-[25px]'>
-        <div className='flex-shrink-0'>
-          <ResponsiveImage
-            src='/icon/ic_arrow_back.svg'
-            alt='뒤로가기'
-            mobile={{ width: 18, height: 18 }}
-            tablet={{ width: 20, height: 20 }}
-            desktop={{ width: 20, height: 20 }}
-          />
-        </div>
-        <span className='ml-[6px] text-[14px] font-medium tablet:text-[16px] desktop:text-[16px]'>
-          돌아가기
-        </span>
-      </div>
+      <BackLink href='/mydashboard' label='돌아가기' />
 
       {/* 프로필 폼 */}
-      <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
-        <div className='mb-[24px] text-[20px] font-bold tablet:mb-[32px] tablet:text-[24px] desktop:mb-[32px] desktop:text-[24px]'>
-          프로필
-        </div>
-        <Form onSubmit={handleProfileSubmit}>
-          <div className='flex flex-col gap-4 tablet:flex-row tablet:items-center'>
-            <div className='flex h-[100px] w-[100px] items-center rounded-[6px] border border-gray bg-gray tablet:h-[182px] tablet:w-[182px] desktop:h-[182px] desktop:w-[182px]'>
-              <ResponsiveImage
-                src='/icon/ic_add_profile.png'
-                alt='프로필 사진 추가'
-                mobile={{ width: 20, height: 20 }}
-                tablet={{ width: 30, height: 30 }}
-                desktop={{ width: 30, height: 30 }}
-              />
-            </div>
-            <div className='flex flex-col gap-4'>
-              <Form.Field
-                label='이메일'
-                type='email'
-                name='profileEmail'
-                value={profileEmail}
-                onChange={(e) => {
-                  setProfileEmail(e.target.value);
-                  setProfileEmailTouched(true);
-                }}
-                placeholder='이메일 입력'
-                error={profileEmailError}
-                showError={profileEmailTouched && !!profileEmailError}
-                width='w-244'
-                tabletWidth='tablet:w-290'
-                desktopWidth='desktop:w-366'
-              />
-              <Form.Field
-                label='닉네임'
-                type='text'
-                name='nickname'
-                value={nickname}
-                onChange={(e) => {
-                  setNickname(e.target.value);
-                  setNicknameTouched(true);
-                }}
-                placeholder='닉네임 입력'
-                error={nicknameError}
-                showError={nicknameTouched && !!nicknameError}
-                width='w-244'
-                tabletWidth='tablet:w-290'
-                desktopWidth='desktop:w-366'
-              />
-            </div>
-          </div>
-          <div className='mt-[16px] flex justify-end tablet:mt-[24px] desktop:mt-[24px]'>
-            <DefaultButton
-              size='lg'
-              disabled={!isProfileFormValid}
-              className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
-            >
-              저장
-            </DefaultButton>
-          </div>
-        </Form>
-      </div>
+      <ProfileUpdate />
+
       <div className='h-[12px]'>{/* 공백 */}</div>
 
       {/* 비밀번호 변경 폼 */}
-      <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
-        <div className='mb-[24px] text-[20px] font-bold tablet:mb-[32px] tablet:text-[24px] desktop:text-[24px]'>
-          비밀번호 변경
-        </div>
-        <Form onSubmit={handlePasswordChangeSubmit}>
-          <Form.Field
-            label='현재 비밀번호'
-            type='password'
-            name='currentPassword'
-            value={currentPassword}
-            onChange={(e) => {
-              setCurrentPassword(e.target.value);
-              setCurrentPasswordTouched(true);
-            }}
-            placeholder='현재 비밀번호 입력'
-            error={currentPasswordError}
-            showError={currentPasswordTouched && !!currentPasswordError}
-            width='w-244'
-            tabletWidth='tablet:w-488'
-            desktopWidth='desktop:w-564'
-          />
-          <Form.Field
-            label='새 비밀번호'
-            type='password'
-            name='newPassword'
-            value={newPassword}
-            onChange={(e) => {
-              setNewPassword(e.target.value);
-              setNewPasswordTouched(true);
-            }}
-            placeholder='새 비밀번호 입력'
-            error={newPasswordError}
-            showError={confirmPasswordTouched && !!confirmPasswordError}
-            width='w-244'
-            tabletWidth='tablet:w-488'
-            desktopWidth='desktop:w-564'
-          />
-          <Form.Field
-            label='새 비밀번호 확인'
-            type='password'
-            name='confirmPassword'
-            value={confirmPassword}
-            onChange={(e) => {
-              setConfirmPassword(e.target.value);
-              setConfirmPasswordTouched(true);
-            }}
-            placeholder='새 비밀번호 다시 입력 '
-            error={confirmPasswordError}
-            showError={confirmPasswordTouched && !!confirmPasswordError}
-            width='w-244'
-            tabletWidth='tablet:w-488'
-            desktopWidth='desktop:w-564'
-          />
-          <div className='mt-[16px] flex justify-end tablet:mt-[24px] desktop:mt-[24px]'>
-            <DefaultButton
-              size='lg'
-              disabled={!isPasswordFormValid}
-              className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
-            >
-              변경
-            </DefaultButton>
-          </div>
-        </Form>
-      </div>
+      <PasswordChange />
     </DashboardLayout>
   );
 };

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,7 +1,76 @@
+import React, { useState, useEffect } from "react";
 import { FC } from "react";
 import DashboardLayout from "@/components/Layout/DashboardLayout";
+import ResponsiveImage from "@/components/ResponsiveImage";
+import Form from "@/components/Form/FormField/FormField";
+import DefaultButton from "@/components/Button";
+import {
+  validateEmail,
+  validateNickname,
+  validatePassword,
+} from "@/lib/validation";
 
-const MyPage: FC = () => {
+const MyPage = () => {
+  // 프로필 Form 상태 변수
+  const [profileEmail, setProfileEmail] = useState<string>("");
+  const [nickname, setNickname] = useState<string>("");
+
+  // 비밀번호 변경 Form 상태 변수
+  const [currentPassword, setCurrentPassword] = useState<string>("");
+  const [newPassword, setNewPassword] = useState<string>("");
+  const [confirmPassword, setConfirmPassword] = useState<string>("");
+
+  // 오류 상태 변수
+  const [profileEmailError, setProfileEmailError] = useState<string>("");
+  const [nicknameError, setNicknameError] = useState<string>("");
+  const [currentPasswordError, setCurrentPasswordError] = useState<string>("");
+  const [newPasswordError, setNewPasswordError] = useState<string>("");
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string>("");
+
+  // Form 유효성 상태 변수
+  const [isProfileFormValid, setIsProfileFormValid] = useState<boolean>(false);
+  const [isPasswordFormValid, setIsPasswordFormValid] =
+    useState<boolean>(false);
+
+  //프로필 Form 유효성 검사
+  useEffect(() => {
+    setProfileEmailError(validateEmail(profileEmail));
+    setNicknameError(validateNickname(nickname));
+    setIsProfileFormValid(
+      !validateEmail(profileEmail) && !validateNickname(nickname),
+    );
+  }, [profileEmail, nickname]);
+
+  //비밀번호 변경 Form 유효성 검사
+  useEffect(() => {
+    setCurrentPasswordError(validatePassword(currentPassword));
+    setNewPasswordError(validatePassword(newPassword));
+    setConfirmPasswordError(
+      newPassword !== confirmPassword ? "새 비밀번호가 일치하지 않습니다." : "",
+    );
+    setIsPasswordFormValid(
+      !validatePassword(currentPassword) &&
+        !validatePassword(newPassword) &&
+        newPassword === confirmPassword,
+    );
+  }, [currentPassword, newPassword, confirmPassword]);
+
+  // 프로필 Form 제출 처리 함수
+  const handleProfileSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!isProfileFormValid) return;
+    // Validation and API call logic for profile update
+    console.log("프로필 업데이트:", { profileEmail, nickname });
+  };
+
+  // 비밀번호 변경 Form 제출 처리 함수
+  const handlePasswordChangeSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!isPasswordFormValid) return;
+    // 비밀번호 변경 로직
+    console.log("비밀번호 변경:", { currentPassword, newPassword });
+  };
+
   return (
     <DashboardLayout
       title='계정관리'
@@ -10,7 +79,136 @@ const MyPage: FC = () => {
       showProfileDropdown={true}
       showCreatedByMeIcon={false}
     >
-      <div>layout설정해서 contents 올바른 위치에 두자!</div>
+      {/* 돌아가기 링크 */}
+      <div className='flex items-center justify-start'>
+        <div className='flex-shrink-0'>
+          <ResponsiveImage
+            src='/icon/ic_arrow_forward.svg'
+            alt='뒤로가기'
+            mobile={{ width: 18, height: 18 }}
+            tablet={{ width: 20, height: 20 }}
+            desktop={{ width: 20, height: 20 }}
+          />
+        </div>
+        <span className='ml-[6px] text-[14px] font-medium tablet:text-[16px] desktop:text-[16px]'>
+          돌아가기
+        </span>
+      </div>
+
+      {/* 프로필 폼 */}
+      <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
+        <div className='text-[20px] font-bold tablet:text-[24px] desktop:text-[24px]'>
+          프로필
+        </div>
+        <Form onSubmit={handleProfileSubmit}>
+          <div className='flex flex-col gap-4 tablet:flex-row tablet:items-center'>
+            <div className='flex h-[100px] w-[100px] items-center rounded-[6px] border border-gray bg-gray tablet:h-[182px] tablet:w-[182px] desktop:h-[182px] desktop:w-[182px]'>
+              <ResponsiveImage
+                src='/icon/ic_add_profile.png'
+                alt='프로필 사진 추가'
+                mobile={{ width: 20, height: 20 }}
+                tablet={{ width: 30, height: 30 }}
+                desktop={{ width: 30, height: 30 }}
+              />
+            </div>
+            <div className='flex flex-col gap-4'>
+              <Form.Field
+                label='이메일'
+                type='email'
+                name='profileEmail'
+                value={profileEmail}
+                onChange={(e) => setProfileEmail(e.target.value)}
+                placeholder='이메일을 입력해 주세요'
+                error={profileEmailError}
+                showError={!!profileEmailError}
+                width='w-244'
+                tabletWidth='tablet:w-290'
+                desktopWidth='desktop:w-366'
+              />
+              <Form.Field
+                label='닉네임'
+                type='text'
+                name='nickname'
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                placeholder='닉네임을 입력해 주세요'
+                error={nicknameError}
+                showError={!!nicknameError}
+                width='w-244'
+                tabletWidth='tablet:w-290'
+                desktopWidth='desktop:w-366'
+              />
+            </div>
+          </div>
+          <div className='flex justify-end'>
+            <DefaultButton
+              size='lg'
+              disabled={!isProfileFormValid}
+              className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
+            >
+              저장
+            </DefaultButton>
+          </div>
+        </Form>
+      </div>
+      <div className='h-[12px]'>{/* 공백 */}</div>
+
+      {/* 비밀번호 변경 폼 */}
+      <div className='w-[284px] rounded-[8px] border border-white bg-white px-[20px] py-[28px] tablet:w-[544px] tablet:px-[28px] tablet:py-[32px] desktop:w-[620px] desktop:px-[28px] desktop:py-[32px]'>
+        <div className='text-[20px] font-bold tablet:text-[24px] desktop:text-[24px]'>
+          비밀번호 변경
+        </div>
+        <Form onSubmit={handlePasswordChangeSubmit}>
+          <Form.Field
+            label='현재 비밀번호'
+            type='password'
+            name='currentPassword'
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            placeholder='현재 비밀번호를 입력해 주세요'
+            error={currentPasswordError}
+            showError={!!currentPasswordError}
+            width='w-244'
+            tabletWidth='tablet:w-488'
+            desktopWidth='desktop:w-564'
+          />
+          <Form.Field
+            label='새 비밀번호'
+            type='password'
+            name='newPassword'
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder='새 비밀번호를 입력해 주세요'
+            error={newPasswordError}
+            showError={!!newPasswordError}
+            width='w-244'
+            tabletWidth='tablet:w-488'
+            desktopWidth='desktop:w-564'
+          />
+          <Form.Field
+            label='새 비밀번호 확인'
+            type='password'
+            name='confirmPassword'
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder='새 비밀번호를 다시 입력해 주세요'
+            error={confirmPasswordError}
+            showError={!!confirmPasswordError}
+            width='w-244'
+            tabletWidth='tablet:w-488'
+            desktopWidth='desktop:w-564'
+          />
+          <div className='flex justify-end'>
+            <DefaultButton
+              size='lg'
+              disabled={!isPasswordFormValid}
+              className='h-[28px] w-[84px] rounded-[4px] text-[12px] text-white tablet:h-[32px] tablet:text-[14px] desktop:h-[32px] desktop:text-[14px]'
+            >
+              변경
+            </DefaultButton>
+          </div>
+        </Form>
+      </div>
     </DashboardLayout>
   );
 };

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -22,7 +22,8 @@ const MyPage: FC = () => {
       {/* 프로필 폼 */}
       <ProfileUpdate />
 
-      <div className='h-[12px]'>{/* 공백 */}</div>
+      {/* 공백 */}
+      <div className='mt-3' />
 
       {/* 비밀번호 변경 폼 */}
       <PasswordChange />


### PR DESCRIPTION
💻 제목 - Feat: My Page UI 완성

## 🔎 작업 내용
- My Page UI 완성
- DashboardLayout에 스크롤 바 추가
- 컴포넌트 분리: MyPage -> BackLink, PasswordChange, ProfileUpdate 
- Form.Field 내용 변경
- Jotai 쓰려고 atoms폴더 생성하고, userAtom만들었습니다.
- 계정관리 들어오면, atom으로 로그인한 계정의 이메일과 닉네임이 자동으로 불러와집니다.
- 이메일 부분은 수정하지 못하도록 disabled 처리했습니다.

## 📜 간단한 코드 설명 및 사용설명서
### FormField
![image](https://github.com/Team2-project/taskify/assets/162412765/b355dda0-ba9f-439d-8ded-aa05b2d2879e)
- Onchange도 설정 선택이 가능하도록 변경했습니다. readOnly와 disabled, width, tableWidth, desktopWidh 값을 설정할 수 있도록 추가했습니다. 
![image](https://github.com/Team2-project/taskify/assets/162412765/9a7d8ea8-23f8-4745-853d-ba48177738a4)
- 회원가입 페이지에 영향이 가지 않도록, 기존 값을 기본값으로 설정했습니다.
![image](https://github.com/Team2-project/taskify/assets/162412765/e0ea5056-9c8c-4fdf-8316-f16e9cfedbbb)
-  readOnly 혹은 disabled를 선택할 경우 커서 불가능, 배경색, 텍스트색상이 다른 필드와 다르게 되도록 설정했습니다.
### ImageUploader 컴포넌트
- 할일생성 Modal에서도 재사용할 수 있도록 컴포넌트 분리했습니다.
- '+' 표시가 My Page와 할일 생성 모달에서 미세하게 다른데, 미세하게 다르니 그냥 써도 좋지 않을까 싶습니다.
- 컴포넌트에 전송로직까지 추가하면 오히려 사용하기가 더 어려워질 것 같아서, 전송로직은 따로 작성해야 합니다.
![image](https://github.com/Team2-project/taskify/assets/162412765/5410a7db-dda5-4868-aa60-5a2d5bb3c66f)
- 적용예시는 위와 같습니다. media 크기마다 사이즈 조정 가능하도록 프롭을 설정했습니다.

## 📷 결과물 (image , gif ..)
![image](https://github.com/Team2-project/taskify/assets/162412765/f087e3ec-baf4-41ce-998a-f6bf6ceed265)

![image](https://github.com/Team2-project/taskify/assets/162412765/519a0562-354c-42dc-88db-e74197c7e5c7)


### 👀 공유포인트 및 이슈
- BackLink 컴포넌트(돌아가기)  의 경우, 대시보드 수정 페이지에서 재사용이 가능합니다. (링크 클릭시 /mydashboard 로 이동)
- 아직 데이터를 전송을 구현하지 않았는데, 다른 컴포넌트에 영향을 미칠 수 있기 때문에 UI 완성본 먼저 PR하고 다른 브랜치 파서 전송로직 구현하려고 합니다.