### PR TITLE
Feat : 카드 생성 모달창 대시보드에 연결

### DIFF
--- a/components/DashBoard/Card/BoardColumn.tsx
+++ b/components/DashBoard/Card/BoardColumn.tsx
@@ -9,6 +9,7 @@ import Button from "@/components/Button";
 import Image from "next/image";
 import CardDetailsModal from "@/components/Modal/CardDetailsModal";
 import ChangeColumn from "@/components/DashBoard/Modal/ChangeColumn";
+import CardAddModal from "@/components/Modal/CardModal/CardAddModal"; // CardAddModal 임포트
 
 interface CardData {
   id: number;
@@ -32,7 +33,7 @@ const BoardColumn: React.FC<Props> = ({ columnId, title, color }: Props) => {
   const [totalCount, setTotalCount] = useState<number>(0);
   const [isCardModalOpen, setCardModalOpen] = useState(false);
   const [isChangeColumnModalOpen, setChangeColumnModalOpen] = useState(false);
-  const [isAddTaskModalOpen, setAddTaskModalOpen] = useState(false);
+  const [isAddTaskModalOpen, setAddTaskModalOpen] = useState(false); // AddTaskModal 상태
   const [selectedCard, setSelectedCard] = useState<CardData | null>(null);
   const [inputValue, setInputValue] = useState("Initial value");
 
@@ -87,12 +88,11 @@ const BoardColumn: React.FC<Props> = ({ columnId, title, color }: Props) => {
   };
 
   const handleOpenAddTaskModal = () => {
-    // Todo : 여기에 이제 할일 추가하는 모달창 연결해야 함!!!
-    setAddTaskModalOpen(true);
+    setAddTaskModalOpen(true); // AddTaskModal 열기
   };
 
   const handleCloseAddTaskModal = () => {
-    setAddTaskModalOpen(false);
+    setAddTaskModalOpen(false); // AddTaskModal 닫기
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -172,7 +172,13 @@ const BoardColumn: React.FC<Props> = ({ columnId, title, color }: Props) => {
         handleCloseModal={handleCloseChangeColumnModal}
         columnId={selectedColumnId} // 선택된 칼럼의 ID를 ChangeColumn에 props로 전달
       />
-      {/* Todo : 카드 생성 모달창(예시. AddTaskModal 컴포넌트)를 여기에 추가할 예정 */}
+      <CardAddModal
+        isOpen={isAddTaskModalOpen}
+        onClose={handleCloseAddTaskModal}
+        createButtonText='생성'
+        cancelButtonText='취소'
+        columnId={columnId} // columnId를 CardAddModal에 전달
+      />
     </div>
   );
 };


### PR DESCRIPTION
💻 제목 - Feat : 카드 생성 모달창 대시보드에 연결

## 🔎 작업 내용
- 대시보드에 컬럼 안의 버튼 클릭하면 새로운 카드 생성 모달창 나오게 연결

## 📜 간단한 코드 설명 및 사용설명서


## 📷 결과물 (image , gif ..)


### 👀 공유포인트 및 이슈
- 동혁님께 : 카드 생성할때 이미지를 삽입하면 잘되는데 이미지 삽입을 안하면 Network에서 이미지 형식이 올바르지 않다고 에러메시지가 나오면서 생성이 안되는 오류가 있습니다. 이미지를 안넣어도 생성이 되게 수정이 필요할것 같습니다.
![image](https://github.com/Team2-project/taskify/assets/115947715/830ac4d4-29a9-430f-8b41-3488d4b6825d)
- 그리고 지금 생성이 잘되는 경우도, 새로고침 전에는 UI상에서 안보여서 이 부분 다른 부분 수정하면서 수정할 예정입니다.