### PR TITLE
Feat: 할일 카드, 생성, 수정 모달 반응형 변경

### DIFF
--- a/components/Modal/CardDetailsModal/index.tsx
+++ b/components/Modal/CardDetailsModal/index.tsx
@@ -52,8 +52,8 @@ const CardDetailsModal: FC<ModalProps> = ({
   };
 
   return (
-    <div className='fixed inset-0 z-50 flex min-w-[370px] items-center justify-center bg-black bg-opacity-50'>
-      <div className='mx-[24px] max-h-screen w-full overflow-y-auto rounded-[8px] bg-white p-[20px] shadow-lg tablet:max-h-[770px] tablet:w-[730px] desktop:max-h-[770px] desktop:w-[730px]'>
+    <div className='fixed inset-0 z-50 flex w-screen h-screen items-center justify-center bg-black bg-opacity-50'>
+      <div className='mx-[24px] h-[90vh] max-w-[80vw] overflow-y-auto rounded-[8px] bg-white p-[20px] shadow-lg tablet:max-h-[770px] tablet:w-[730px] desktop:max-h-[770px] desktop:w-[730px]'>
         <Header
           title={cardDetails.title}
           cardId={cardId}

--- a/components/Modal/CardModal/CardAddModal.tsx
+++ b/components/Modal/CardModal/CardAddModal.tsx
@@ -162,8 +162,8 @@ export default function CardAddModal({
   if (!isOpen) return null;
 
   return (
-    <div className='fixed inset-0 box-border h-full w-full border bg-black bg-opacity-50'>
-      <div className='fixed inset-0 m-auto h-[766px] w-[327px] rounded-[8px] bg-white px-[20px] pb-[20px] pt-[28px] tablet:h-[907px] tablet:w-[506px] tablet:px-[28px] tablet:pb-[28px] tablet:pt-[32px]'>
+    <div className='fixed inset-0 box-border h-screen w-screen border bg-black bg-opacity-50'>
+      <div className='fixed inset-0 m-auto h-[90vh] max-w-[80vw] overflow-auto rounded-[8px] bg-white px-[20px] pb-[20px] pt-[28px] tablet:h-[95vh] tablet:max-w-[50vw] tablet:px-[28px] tablet:pb-[28px] tablet:pt-[32px]'>
         <h1 className='text-[20px] font-bold tablet:text-[24px]'>할 일 생성</h1>
         <form
           onSubmit={(e) => {

--- a/components/Modal/CardModal/CardEditModal.tsx
+++ b/components/Modal/CardModal/CardEditModal.tsx
@@ -271,7 +271,7 @@ const CardEditModal: FC<ModalProps> = ({
 
   return (
     <div className='fixed inset-0 box-border h-full w-full border bg-black bg-opacity-50'>
-      <div className='fixed inset-0 m-auto h-[869px] w-[327px] rounded-[8px] bg-white px-[20px] pb-[20px] pt-[28px] tablet:h-[907px] tablet:w-[506px] tablet:px-[28px] tablet:pb-[28px] tablet:pt-[32px]'>
+      <div className='fixed inset-0 m-auto h-[90vh] max-w-[80vw] overflow-auto rounded-[8px] bg-white px-[20px] pb-[20px] pt-[28px] tablet:h-[95vh] tablet:max-w-[50vw] tablet:px-[28px] tablet:pb-[28px] tablet:pt-[32px]'>
         <div className='text-[20px] font-bold tablet:text-[24px]'>
           할 일 수정
         </div>
@@ -353,3 +353,4 @@ const CardEditModal: FC<ModalProps> = ({
 };
 
 export default CardEditModal;
+


### PR DESCRIPTION
💻 제목 - Feat: 할일 카드, 생성, 수정 모달 반응형 변경

## 🔎 작업 내용
- 윈도우,맥 환경에서 모달의 크기가 다르게 보이는 현상이 있어 반응형 css 추가로 수정함
- vh, vw 적용, 넘치는 부분은 overflow 적용

## 📜 간단한 코드 설명 및 사용설명서

## 📷 결과물 (image , gif ..)
- CardDetailsModal
<img width="825" alt="스크린샷 2024-07-05 오후 4 53 17" src="https://github.com/Team2-project/taskify/assets/156271070/e1522069-30ac-4a9e-af87-64397b822752">

- CardEditModal
<img width="825" alt="스크린샷 2024-07-05 오후 4 54 04" src="https://github.com/Team2-project/taskify/assets/156271070/56d3461e-55e8-44ae-84b5-8d604c8e0380">

- CardAddModal
<img width="825" alt="스크린샷 2024-07-05 오후 4 55 13" src="https://github.com/Team2-project/taskify/assets/156271070/42f9f456-9887-49bd-83a7-ee391a8a47b3">

### 👀 공유포인트 및 이슈
