### PR TITLE
Refactor : react-key, atom 이용해서 내가 만든 부분 새로고침 안해도 반영되게 수정

### DIFF
--- a/atoms/dashboardAtom.ts
+++ b/atoms/dashboardAtom.ts
@@ -1,0 +1,5 @@
+// atoms/dashboardAtom.ts
+import { atom } from 'jotai';
+
+export const dashboardTitleAtom = atom<string>('');
+export const dashboardColorAtom = atom<string>('');

--- a/components/DashBoardEdit/InvitationList.tsx
+++ b/components/DashBoardEdit/InvitationList.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/Button";
 import fetcher from "@/lib/api/fetcher";
 import { useRouter } from "next/router";
 import { DashboardInvitationsResponse } from "@/lib/api/types/dashboards";
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosRequestConfig } from "axios";
 import DashBoardForm from "./components/DashBoardForm";
 import InvitationModal from "./InvitationModal";
@@ -26,6 +26,8 @@ const InvitationList: React.FC = () => {
   const router = useRouter();
   const { dashboardId } = router.query;
 
+  const queryClient = useQueryClient();
+
   const invitationsConfig: AxiosRequestConfig = {
     url: `/dashboards/${dashboardId}/invitations?page=${page}&size=${size}`,
     method: "GET",
@@ -36,23 +38,28 @@ const InvitationList: React.FC = () => {
     error: invitationsError,
     isLoading: invitationsLoading,
     refetch: refetchInvitations,
-  }: UseQueryResult<DashboardInvitationsResponse, Error> = useQuery({
+  } = useQuery({
     queryKey: ["invitationsData", dashboardId, page],
     queryFn: () => fetcher<DashboardInvitationsResponse>(invitationsConfig),
     enabled: !!dashboardId,
   });
 
-  const handleButtonClick = async (invitationId: number) => {
-    try {
-      await fetcher({
+  const mutation = useMutation({
+    mutationFn: (invitationId: number) =>
+      fetcher({
         url: `dashboards/${dashboardId}/invitations/${invitationId}`,
         method: "DELETE",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["invitationsData", dashboardId, page],
       });
+    },
+  });
 
-      setDeletedInvitations((prevDeleted) => [...prevDeleted, invitationId]);
-    } catch (error) {
-      console.error(error);
-    }
+  const handleButtonClick = (invitationId: number) => {
+    mutation.mutate(invitationId);
+    setDeletedInvitations((prevDeleted) => [...prevDeleted, invitationId]);
   };
 
   const handleInvitation = () => {

--- a/components/DashBoardEdit/InvitationList.tsx
+++ b/components/DashBoardEdit/InvitationList.tsx
@@ -122,16 +122,22 @@ const InvitationList: React.FC = () => {
         </DashBoardForm>
       </div>
 
-      <div className='flex flex-col gap-[24px]'>
-        {filteredInvitations.map((invitation) => (
-          <CustomComponent
-            key={invitation.id}
-            title={invitation.invitee.email}
-            buttonLabel='취소'
-            onButtonClick={() => handleButtonClick(invitation.id)}
-          />
-        ))}
-      </div>
+      {filteredInvitations.length === 0 ? (
+        <div className='mt-[100px] flex justify-center'>
+          <p>초대 요청한 구성원이 없습니다</p>
+        </div>
+      ) : (
+        <div className='flex flex-col gap-[24px]'>
+          {filteredInvitations.map((invitation) => (
+            <CustomComponent
+              key={invitation.id}
+              title={invitation.invitee.email}
+              buttonLabel='취소'
+              onButtonClick={() => handleButtonClick(invitation.id)}
+            />
+          ))}
+        </div>
+      )}
 
       <InvitationModal
         isModalOpen={isModalOpen}

--- a/components/Layout/DashboardLayout.tsx
+++ b/components/Layout/DashboardLayout.tsx
@@ -15,6 +15,7 @@ import { membersAtom } from "@/atoms/membersAtom";
 import { DashboardDetailResponse } from "@/lib/api/types/dashboards";
 import useFetchMembers from "@/hooks/useFetchMembers";
 import useFetchUser from "@/hooks/useFetchUser";
+import { dashboardTitleAtom } from "@/atoms/dashboardAtom";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -49,6 +50,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({
   } = useFetchMembers(dashboardId || 0);
   const [user, setUser] = useAtom(userAtom);
   const [members, setMembers] = useAtom(membersAtom);
+  const [dashboardTitle] = useAtom(dashboardTitleAtom);
 
   useEffect(() => {
     if (userData) {
@@ -90,7 +92,7 @@ const DashboardLayout: FC<DashboardLayoutProps> = ({
     return <div>데이터를 불러오는 중 오류가 발생했습니다</div>;
   }
 
-  const DashboardTitle = title || (dashboardData ? dashboardData.title : "");
+  const DashboardTitle = title || dashboardTitle;
   const createdByMe = dashboardData ? dashboardData.createdByMe : false;
 
   return (

--- a/components/Modal/BasicModal.tsx
+++ b/components/Modal/BasicModal.tsx
@@ -6,7 +6,7 @@ interface ModalProps {
   isOpen: boolean;
   value: string;
   onClose: () => void;
-  buttonAction?: () => void;
+  buttonAction?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   cancelButtonText: string;
@@ -41,9 +41,9 @@ export default function BasicModal({
     setButtonDisabled(value.trim() === "");
   }, [value]);
 
-  const handleButtonClick = () => {
+  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (buttonAction) {
-      buttonAction();
+      buttonAction(e);
     }
     onClose();
   };

--- a/components/SideMenu/ButtonList.tsx
+++ b/components/SideMenu/ButtonList.tsx
@@ -17,7 +17,7 @@ const getDashboard = (): DashboardResponse[] | null | JSX.Element => {
     url: "/dashboards",
     method: "GET",
     params: {
-      navigationMethod: "infiniteScroll",
+      navigationMethod: "pagination",
       size: 40,
     },
   };

--- a/components/SideMenu/ButtonList.tsx
+++ b/components/SideMenu/ButtonList.tsx
@@ -1,65 +1,88 @@
 import fetcher from "@/lib/api/fetcher";
-import { DashboardsResponse, DashboardResponse } from "@/lib/api/types/dashboards";
+import {
+  DashboardsResponse,
+  DashboardResponse,
+} from "@/lib/api/types/dashboards";
 import { useQuery } from "@tanstack/react-query";
-import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { AxiosRequestConfig } from "axios";
 import ColorChip from "@/public/chip/circle_small.svg";
-import CrownIcon from "@/public/icon/ic_crown.svg"
+import CrownIcon from "@/public/icon/ic_crown.svg";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useAtom } from "jotai";
+import { dashboardTitleAtom, dashboardColorAtom } from "@/atoms/dashboardAtom";
 
-//eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDA5NywidGVhbUlkIjoiNi0yIiwiaWF0IjoxNzE5OTYwNjYwLCJpc3MiOiJzcC10YXNraWZ5In0.9YZREbJn1sstQkOI4v7rm0xo_pkbM1PD6-Fd7GmoCfA
-
-const getDashboard = ():DashboardResponse[] | null | JSX.Element => {
-
+const getDashboard = (): DashboardResponse[] | null | JSX.Element => {
   const config: AxiosRequestConfig = {
-    url:"/dashboards",  
+    url: "/dashboards",
     method: "GET",
-    params:{
-      navigationMethod:"pagination"
-    }
+    params: {
+      navigationMethod: "pagination",
+    },
   };
-  
+
   const {
     data: dashboardData,
     error: dashboardError,
     isLoading: dashboardloading,
   } = useQuery<DashboardsResponse>({
-    queryKey: ["DashboardsResponse"], 
+    queryKey: ["DashboardsResponse"],
     queryFn: () => fetcher<DashboardsResponse>(config),
   });
-  
-  if(dashboardloading) {
-    return <div>Loading...</div>
-  };
-  if(dashboardError || !dashboardData){
+
+  if (dashboardloading) {
+    return <div>Loading...</div>;
+  }
+  if (dashboardError || !dashboardData) {
     return null;
-  };
-  
+  }
+
   const dashboardArray = dashboardData.dashboards;
 
-  return dashboardArray
+  return dashboardArray;
 };
-
 
 const ButtonList = () => {
   const router = useRouter();
   const { dashboardId } = router.query;
-  const dashboardArray = getDashboard()
+  const dashboardArray = getDashboard();
 
-  if(Array.isArray(dashboardArray)){
-    return(
-      <div className="flex flex-col-reverse justify-start items-start">
-      {dashboardArray.map((dashboard:DashboardResponse, index:number)=>(
-        <Link href={`/dashboard/${dashboard.id}`}>
-          <button key={index} className="flex justify-start items-center w-[276px] h-[45px] cursor-pointer active:bg-[#F1EFFD] rounded-[4px] max-desktop:w-[134px] max-tablet:w-fit">
-            <ColorChip fill={dashboard.color}/>
-            <p className="flex items-center justify-start gap-2 text-gray-50 max-desktop:gap-1.5 max-tablet:hidden">{dashboard.title}{dashboard.createdByMe ? <CrownIcon className="w-[18px] h-[14px] viewBox-[0 0 18 14] max-desktop:w-[16px] max-desktop:h-[12px]"/> : null}</p>
-            </button>
-        </Link>))
-        }
-        </div> 
-    )
+  // Atoms를 사용하여 제목과 색상을 가져옴
+  const [dashboardTitle] = useAtom(dashboardTitleAtom);
+  const [dashboardColor] = useAtom(dashboardColorAtom);
+
+  if (Array.isArray(dashboardArray)) {
+    return (
+      <div className='flex flex-col-reverse items-start justify-start'>
+        {dashboardArray.map((dashboard: DashboardResponse, index: number) => {
+          const isCurrentDashboard = dashboard.id === Number(dashboardId);
+          const title =
+            isCurrentDashboard && dashboardTitle
+              ? dashboardTitle
+              : dashboard.title;
+          const color =
+            isCurrentDashboard && dashboardColor
+              ? dashboardColor
+              : dashboard.color;
+
+          return (
+            <Link href={`/dashboard/${dashboard.id}`} key={index}>
+              <button className='flex h-[45px] w-[276px] cursor-pointer items-center justify-start rounded-[4px] active:bg-[#F1EFFD] max-desktop:w-[134px] max-tablet:w-fit'>
+                <ColorChip fill={color} />
+                <p className='flex items-center justify-start gap-2 text-gray-50 max-desktop:gap-1.5 max-tablet:hidden'>
+                  {title}
+                  {dashboard.createdByMe ? (
+                    <CrownIcon className='viewBox-[0 0 18 14] h-[14px] w-[18px] max-desktop:h-[12px] max-desktop:w-[16px]' />
+                  ) : null}
+                </p>
+              </button>
+            </Link>
+          );
+        })}
+      </div>
+    );
   }
-}
+  return null;
+};
 
 export default ButtonList;

--- a/components/SideMenu/ButtonList.tsx
+++ b/components/SideMenu/ButtonList.tsx
@@ -17,7 +17,8 @@ const getDashboard = (): DashboardResponse[] | null | JSX.Element => {
     url: "/dashboards",
     method: "GET",
     params: {
-      navigationMethod: "pagination",
+      navigationMethod: "infiniteScroll",
+      size: 40,
     },
   };
 
@@ -38,7 +39,6 @@ const getDashboard = (): DashboardResponse[] | null | JSX.Element => {
   }
 
   const dashboardArray = dashboardData.dashboards;
-
   return dashboardArray;
 };
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -60,6 +60,16 @@ const LoginPage = () => {
   };
 
   useEffect(() => {
+    // 페이지 진입 시 쿠키에서 accessToken을 가져옴
+    const accessToken = Cookies.get("accessToken");
+
+    // 만약 accessToken이 존재한다면, 이미 로그인된 상태이므로 대시보드 페이지로 리다이렉트
+    if (accessToken) {
+      router.push("/mydashboard");
+    }
+  }, []);
+
+  useEffect(() => {
     const emailValidation = validateEmail(email);
     const passwordValidation = validatePassword(password);
 

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/validation";
 import Modal from "@/components/Modal/AlarmModal";
 import { useRouter } from "next/router";
+import Cookies from "js-cookie";
 
 interface SignupData {
   email: string;
@@ -114,6 +115,13 @@ const SignupPage = () => {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    const accessToken = Cookies.get("accessToken");
+    if (accessToken) {
+      router.push("/mydashboard");
+    }
+  }, []);
 
   useEffect(() => {
     const emailValidation = validateEmail(email);


### PR DESCRIPTION
💻 제목 - Refactor : react-key, atom 이용해서 내가 만든 부분 새로고침 안해도 반영되게 수정

## 🔎 작업 내용
- 대시보드 수정 페이지 안에서 대시보드 수정, 구성원 삭제, 초대 내역 새로고침 안해도 수정되게 설정
- 사이드바 대시보드 최대 40개 데이터 가지고 오도록 수정

## 📜 간단한 코드 설명 및 사용설명서


## 📷 결과물 (image , gif ..)
<img width="522" alt="image" src="https://github.com/Team2-project/taskify/assets/115947715/bfdb9b08-695d-4fac-9a9d-37e3a8875dc7">


### 👀 공유포인트 및 이슈
