### PR TITLE
Refactor: CardAddModal Img 전송오류, TagInput 태그 2개씩 만들어지는 오류 해결

### DIFF
--- a/components/Input/TagInput.tsx
+++ b/components/Input/TagInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 interface TagInputProps {
   value?: string;
@@ -28,27 +28,15 @@ export default function TagInput({
     { id: number; tag: string; bgColor: string; textColor: string }[]
   >([]);
 
-  useEffect(() => {
-    if (value) {
-      setHashArr(
-        value.split(",").map((tag, index) => {
-          const color = colors[Math.floor(Math.random() * colors.length)];
-          return {
-            id: index,
-            tag: tag.trim(),
-            bgColor: color.bgColor,
-            textColor: color.textColor,
-          };
-        }),
-      );
-    }
-  }, [value]);
-
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
         if (e.currentTarget.value.trim() !== "") {
+          if (hashArr.length >= 5) {
+            alert("최대 5개의 해시태그만 추가할 수 있습니다.");
+            return;
+          }
           const color = colors[Math.floor(Math.random() * colors.length)];
           const newTag = {
             id: Date.now(),
@@ -68,11 +56,11 @@ export default function TagInput({
 
   const onChangeHashtag = (e: React.ChangeEvent<HTMLInputElement>) => {
     setHashtag(e.target.value);
-    onChange && onChange(e);
+    if (onChange) onChange(e);
   };
 
   const removeTag = (idToRemove: number) => {
-    const newHashArr = hashArr.filter((item) => item.id !== idToRemove);
+    const newHashArr = hashArr.filter((tag) => tag.id !== idToRemove);
     setHashArr(newHashArr);
     handleTagChange(newHashArr.map((item) => item.tag));
   };
@@ -82,21 +70,25 @@ export default function TagInput({
       <div className='text-[16px] font-medium tablet:text-[18px]'>
         {subTitle}
       </div>
-      <div className='relative flex h-[42px] w-full items-center justify-center rounded-[6px] border-[1px] border-gray-30 p-3 tablet:h-[48px]'>
+      <div
+        id='modal'
+        className='relative flex h-[42px] w-full items-center justify-center rounded-[6px] border-[1px] border-gray-30 p-3 tablet:h-[48px]'
+      >
         <div className='flex w-full flex-nowrap items-center gap-[6px] overflow-hidden'>
           {hashArr.map((item) => (
             <div
               key={item.id}
-              className={`flex items-center justify-center gap-[5px] rounded-[6px] px-[7px] ${item.bgColor} tablet:gap-[7px]`}
+              className={`flex items-center justify-center gap-[5px] rounded-[6px] px-[7px] ${item.bgColor} ${item.textColor} tablet:gap-[7px]`}
               style={{
                 maxWidth: "150px",
                 overflow: "hidden",
                 whiteSpace: "nowrap",
                 textOverflow: "ellipsis",
               }}
+              onClick={() => removeTag(item.id)}
             >
               <div
-                className={`text-[10px] font-normal tablet:text-[12px] ${item.textColor}`}
+                className='text-[10px] font-normal tablet:text-[12px]'
                 style={{
                   overflow: "hidden",
                   whiteSpace: "nowrap",
@@ -105,12 +97,7 @@ export default function TagInput({
               >
                 {item.tag}
               </div>
-              <span
-                className='cursor-pointer font-semibold'
-                onClick={() => removeTag(item.id)}
-              >
-                &times;
-              </span>
+              <span className='cursor-pointer font-semibold'>&times;</span>
             </div>
           ))}
           {hashArr.length < 5 && (
@@ -127,4 +114,3 @@ export default function TagInput({
     </div>
   );
 }
-

--- a/components/Input/TagInput.tsx
+++ b/components/Input/TagInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 
 interface TagInputProps {
   value?: string;
@@ -27,10 +27,11 @@ export default function TagInput({
   const [hashArr, setHashArr] = useState<
     { id: number; tag: string; bgColor: string; textColor: string }[]
   >([]);
+  const [isComposing, setIsComposing] = useState<boolean>(false);
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
+      if (!isComposing && e.key === "Enter") {
         e.preventDefault();
         if (e.currentTarget.value.trim() !== "") {
           if (hashArr.length >= 5) {
@@ -51,7 +52,7 @@ export default function TagInput({
         }
       }
     },
-    [hashArr, handleTagChange],
+    [hashArr, handleTagChange, isComposing],
   );
 
   const onChangeHashtag = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -64,6 +65,21 @@ export default function TagInput({
     setHashArr(newHashArr);
     handleTagChange(newHashArr.map((item) => item.tag));
   };
+
+  useEffect(() => {
+    const inputElement = document.querySelector("#tagInput") as HTMLInputElement;
+
+    const handleCompositionStart = () => setIsComposing(true);
+    const handleCompositionEnd = () => setIsComposing(false);
+
+    inputElement.addEventListener("compositionstart", handleCompositionStart);
+    inputElement.addEventListener("compositionend", handleCompositionEnd);
+
+    return () => {
+      inputElement.removeEventListener("compositionstart", handleCompositionStart);
+      inputElement.removeEventListener("compositionend", handleCompositionEnd);
+    };
+  }, []);
 
   return (
     <div className='mt-[18px] flex flex-col gap-[10px] tablet:mt-[26px]'>
@@ -102,6 +118,7 @@ export default function TagInput({
           ))}
           {hashArr.length < 5 && (
             <input
+              id="tagInput"
               placeholder={placeholder}
               className='flex-grow text-[10px] font-normal outline-none tablet:text-[12px]'
               value={hashtag}

--- a/components/Modal/CardModal/CardAddModal.tsx
+++ b/components/Modal/CardModal/CardAddModal.tsx
@@ -118,9 +118,13 @@ export default function CardAddModal({
   };
 
   const handleButtonClick = async () => {
-    let imgData = "";
+    let imgData: string= "";
     if (imgFile) {
-      imgData = await uploadCardImg(columnId, imgFile);
+      try {
+        imgData = await uploadCardImg(columnId, imgFile);
+      } catch (error) {
+        throw error;
+      }
     }
 
     const cardData: CreateCardData = {
@@ -131,6 +135,7 @@ export default function CardAddModal({
       description: textData,
       dueDate: startDate || "",
       tags: tagData,
+      ...(imgData ? { imageUrl: imgData } : {}),
     };
 
     mutation.mutate(cardData);

--- a/lib/api/types/cards.ts
+++ b/lib/api/types/cards.ts
@@ -11,7 +11,7 @@ export interface CreateCardData {
   description: string;
   dueDate: string;
   tags: string[];
-  // imageUrl: string ;
+  imageUrl?: string;
 }
 
 // 카드 목록 조회 시 반환되는 데이터 타입


### PR DESCRIPTION
💻 제목 - Refactor: CardAddModal Img 전송오류, TagInput 태그 2개씩 만들어지는 오류 해결

## 🔎 작업 내용
- CardAddModal Img 전송오류 해결 (이미지 삽입 했을때만 카드 생성이 안되는 오류가 생겨 수정함)
- TagInput 태그 2개씩 만들어지는 오류 해결 (input에 값 입력후 엔터하면 tag가 하나가 만들어져야 하는데 2개 만들어져서 수정함)

## 📜 간단한 코드 설명 및 사용설명서
- CardAddModal Img 전송오류 해결 (사진 o , 사진 x)(정상작동)
<img width="760" alt="스크린샷 2024-07-06 오후 9 46 48" src="https://github.com/Team2-project/taskify/assets/156271070/9c637b0e-9549-45a8-97c5-9b7302e762b3">

- TagInput 태그 2개씩 만들어지는 오류 해결 (하나씩 잘 만들어짐)
<img width="488" alt="스크린샷 2024-07-06 오후 9 52 16" src="https://github.com/Team2-project/taskify/assets/156271070/f2e49cd0-cd63-4bc6-8d53-69fd9544c56c">


## 📷 결과물 (image , gif ..)


### 👀 공유포인트 및 이슈
#### 현상
태그가 2개씩 만들어지는 현상이 알고보니 영어를 사용할때는 정상 작동하는데
한국어를 사용하면 ex) "고구마" 엔터치면 "고구마" "마" 이런식으로 뒷글자 하나만 가지고와서 태그 2개가 만들어짐

#### 원인
한국어 입력 시 태그가 두 번 생성되는 문제는 브라우저의 IME(Input Method Editor) 입력 방식과 관련이 있음
특히, IME가 활성화되어 있는 상태에서는 onKeyDown 이벤트가 두 번 이상 호출될 수 있음 (하..)

#### 결과
이 문제를 해결하기 위해 compositionstart, compositionupdate, compositionend 이벤트를 사용하여 IME 입력 상태를 관리하고, IME 입력이 완료된 후에만 태그를 추가하도록 함

const [isComposing, setIsComposing] = useState<boolean>(false);

useEffect(() => {
    const inputElement = document.querySelector("#tagInput") as HTMLInputElement;

    const handleCompositionStart = () => setIsComposing(true);
    const handleCompositionEnd = () => setIsComposing(false);

    inputElement.addEventListener("compositionstart", handleCompositionStart);
    inputElement.addEventListener("compositionend", handleCompositionEnd);

    return () => {
      inputElement.removeEventListener("compositionstart", handleCompositionStart);
      inputElement.removeEventListener("compositionend", handleCompositionEnd);
    };
  }, []);
