### PR TITLE
Refactor: Dashboard 데이터 호출 구조 개선 & 캐싱 무효화 처리

### DIFF
--- a/components/SideMenu/AddDashBoardButton.tsx
+++ b/components/SideMenu/AddDashBoardButton.tsx
@@ -1,80 +1,58 @@
 import useClickOutside from "@/hooks/useClickOutside";
 import CreateDashBoard from "@/components/Modal/CreateDashBoard/CreateDashBoard";
 import { useState, ChangeEvent } from "react";
-import { AxiosRequestConfig } from "axios";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CreateDashboardRequest, DashboardResponse } from "@/lib/api/types/dashboards";
-import fetcher from "@/lib/api/fetcher";
+import useDashboard from "@/hooks/useDashboard";
 
 const AddDashboardButton = () => {
-  const [modalOpen, setModalOpen] = useState(false)
-  const [inputValue, setInputValue] = useState('')
+  const [modalOpen, setModalOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const { addDashboard } = useDashboard();
 
-  const colors: { [key: string]: string } =
-  {"green":"#7AC555",
-    "purple":"#760DDE",
-    "orange":"#FFA500",
-    "blue":"#76A5EA",
-    "pink":"#E876EA"
+  const colors: { [key: string]: string } = {
+    green: "#7AC555",
+    purple: "#760DDE",
+    orange: "#FFA500",
+    blue: "#76A5EA",
+    pink: "#E876EA",
   };
-  
-  function getColor(key: string):string{
+
+  function getColor(key: string): string {
     return colors[key];
   }
 
-  const queryClient = useQueryClient();
-
-  const mutation = useMutation({
-    mutationFn: async ({title, color}:CreateDashboardRequest) => {
-      const response = await fetcher<DashboardResponse>({
-        url: "/dashboards",
-        method: "POST",
-        data: {title, color}
-      });
-      return response;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["DashboardsResponse"]
-      });
-      setModalOpen(false)},
-      onError: (error) => {
-          console.error(error)
-        }
-    }
-  )
   const postDashboard = (e: React.FormEvent, color: string) => {
-    // 자식 컴포넌트가 부모 컴포넌트한테 값을 전달해주려면
-    // 함수를 통해, (함수의 parameter를 통해) 전달이 가능하다!
-
-    const colorCode = getColor(color);
     e.preventDefault();
-
-    
-    mutation.mutate({title: inputValue, color:colorCode})
+    const colorCode = getColor(color);
+    addDashboard({ title: inputValue, color: colorCode });
+    setModalOpen(false); // 모달 닫기
   };
 
-  const handleChangeInput = (e:ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value)
+  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
   };
-
   return (
     <>
-      <button onClick={()=>setModalOpen(true)} className='flex h-[20px] w-[276px] items-center justify-between max-desktop:w-[112px] max-tablet:w-[67px] max-tablet:justify-center'>
+      <button
+        onClick={() => setModalOpen(true)}
+        className='flex h-[20px] w-[276px] items-center justify-between max-desktop:w-[112px] max-tablet:w-[67px] max-tablet:justify-center'
+      >
         <p className='text-[12px] max-tablet:hidden'>Dash Boards</p>
-        <img src='/icon/ic_add_dashboard.svg' className='h-[20px] w-[20px]'/>
+        <img src='/icon/ic_add_dashboard.svg' className='h-[20px] w-[20px]' />
       </button>
       <CreateDashBoard
         isOpen={modalOpen}
-        title={'새로운 대시보드'}
+        title={"새로운 대시보드"}
         value={inputValue}
-        subTitle={'대시보드 이름'} 
-        placeholder={'대시보드 이름'} 
-        createButtonText={"생성"} 
-        cancelButtonText={"취소"} 
-        onClose={()=>{setModalOpen(false)}} 
-        onSubmit={postDashboard} 
-        onChange={handleChangeInput}/>
+        subTitle={"대시보드 이름"}
+        placeholder={"대시보드 이름"}
+        createButtonText={"생성"}
+        cancelButtonText={"취소"}
+        onClose={() => {
+          setModalOpen(false);
+        }}
+        onSubmit={postDashboard}
+        onChange={handleChangeInput}
+      />
     </>
   );
 };

--- a/components/SideMenu/AddDashBoardButton.tsx
+++ b/components/SideMenu/AddDashBoardButton.tsx
@@ -1,35 +1,9 @@
-import useClickOutside from "@/hooks/useClickOutside";
-import CreateDashBoard from "@/components/Modal/CreateDashBoard/CreateDashBoard";
-import { useState, ChangeEvent } from "react";
-import useDashboard from "@/hooks/useDashboard";
+import React, { useState } from "react";
+import CreateDashBoardModal from "./CreateDashBoardModal"; // 새로운 모달 컴포넌트로 변경
 
 const AddDashboardButton = () => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [inputValue, setInputValue] = useState("");
-  const { addDashboard } = useDashboard();
 
-  const colors: { [key: string]: string } = {
-    green: "#7AC555",
-    purple: "#760DDE",
-    orange: "#FFA500",
-    blue: "#76A5EA",
-    pink: "#E876EA",
-  };
-
-  function getColor(key: string): string {
-    return colors[key];
-  }
-
-  const postDashboard = (e: React.FormEvent, color: string) => {
-    e.preventDefault();
-    const colorCode = getColor(color);
-    addDashboard({ title: inputValue, color: colorCode });
-    setModalOpen(false); // 모달 닫기
-  };
-
-  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-  };
   return (
     <>
       <button
@@ -37,21 +11,15 @@ const AddDashboardButton = () => {
         className='flex h-[20px] w-[276px] items-center justify-between max-desktop:w-[112px] max-tablet:w-[67px] max-tablet:justify-center'
       >
         <p className='text-[12px] max-tablet:hidden'>Dash Boards</p>
-        <img src='/icon/ic_add_dashboard.svg' className='h-[20px] w-[20px]' />
+        <img
+          src='/icon/ic_add_dashboard.svg'
+          className='h-[20px] w-[20px]'
+          alt='Dashboard'
+        />
       </button>
-      <CreateDashBoard
+      <CreateDashBoardModal
         isOpen={modalOpen}
-        title={"새로운 대시보드"}
-        value={inputValue}
-        subTitle={"대시보드 이름"}
-        placeholder={"대시보드 이름"}
-        createButtonText={"생성"}
-        cancelButtonText={"취소"}
-        onClose={() => {
-          setModalOpen(false);
-        }}
-        onSubmit={postDashboard}
-        onChange={handleChangeInput}
+        onClose={() => setModalOpen(false)}
       />
     </>
   );

--- a/components/SideMenu/ButtonList.tsx
+++ b/components/SideMenu/ButtonList.tsx
@@ -1,96 +1,59 @@
-import fetcher from "@/lib/api/fetcher";
-import {
-  DashboardsResponse,
-  DashboardResponse,
-} from "@/lib/api/types/dashboards";
-import { useQuery } from "@tanstack/react-query";
-import { AxiosRequestConfig } from "axios";
 import ColorChip from "@/public/chip/circle_small.svg";
 import CrownIcon from "@/public/icon/ic_crown.svg";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { useAtom } from "jotai";
-import { dashboardTitleAtom, dashboardColorAtom } from "@/atoms/dashboardAtom";
-
-const getDashboard = (): DashboardResponse[] | null | JSX.Element => {
-  const config: AxiosRequestConfig = {
-    url: "/dashboards",
-    method: "GET",
-    params: {
-      navigationMethod: "pagination",
-      size: 40,
-    },
-  };
-
-  const {
-    data: dashboardData,
-    error: dashboardError,
-    isLoading: dashboardloading,
-  } = useQuery<DashboardsResponse>({
-    queryKey: ["DashboardsResponse"],
-    queryFn: () => fetcher<DashboardsResponse>(config),
-  });
-
-  if (dashboardloading) {
-    return <div>Loading...</div>;
-  }
-  if (dashboardError || !dashboardData) {
-    return null;
-  }
-
-  const dashboardArray = dashboardData.dashboards;
-  return dashboardArray;
-};
+import useDashboard from "@/hooks/useDashboard";
+import { DashboardResponse } from "@/lib/api/types/dashboards";
 
 const ButtonList = () => {
   const router = useRouter();
   const { dashboardId } = router.query;
-  const dashboardArray = getDashboard();
 
-  // Atoms를 사용하여 제목과 색상을 가져옴
-  const [dashboardTitle] = useAtom(dashboardTitleAtom);
-  const [dashboardColor] = useAtom(dashboardColorAtom);
+  // useDashboard 훅을 사용하여 대시보드 데이터를 가져옵니다.
+  const { dashboards, isLoading, error } = useDashboard();
 
   //버튼 클릭 시 색 변하도록 하는 함수
-  type buttonColor = number;
-  const [buttonColor,setButtonColor] = useState(-1);
-  const handleButtonColor = (index:number) => {
-    return setButtonColor(index)
+  const [buttonColor, setButtonColor] = useState<number | null>(null);
+  const handleButtonColor = (index: number) => {
+    setButtonColor(index);
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (error || !dashboards) {
+    return null;
   }
 
-  if (Array.isArray(dashboardArray)) {
-    return (
-      <div className='flex flex-col-reverse items-start justify-start'>
-        {dashboardArray.map((dashboard: DashboardResponse, index: number) => {
-          const isCurrentDashboard = dashboard.id === Number(dashboardId);
-          const title =
-            isCurrentDashboard && dashboardTitle
-              ? dashboardTitle
-              : dashboard.title;
-          const color =
-            isCurrentDashboard && dashboardColor
-              ? dashboardColor
-              : dashboard.color;
+  return (
+    <div className='flex flex-col-reverse items-start justify-start'>
+      {dashboards.map((dashboard: DashboardResponse, index: number) => {
+        const isCurrentDashboard = dashboard.id === Number(dashboardId);
+        const title = dashboard.title;
+        const color = dashboard.color;
 
-          return (
-            <Link href={`/dashboard/${dashboard.id}`} key={index}>
-              <button onClick={()=>handleButtonColor(index)} className={`${buttonColor === index ? 'bg-[#F1EFFD]' : 'bg-none'} flex h-[45px] w-[276px] cursor-pointer items-center justify-start rounded-[4px] hover:bg-[#F1EFFD] max-desktop:w-[134px] max-tablet:w-fit`}>
-                <ColorChip fill={color} />
-                <p className='flex items-center justify-start gap-2 text-gray-50 truncate max-desktop:gap-1.5 max-tablet:hidden'>
-                  {title}
-                  {dashboard.createdByMe ? (
-                    <CrownIcon className='viewBox-[0 0 18 14] h-[14px] w-[18px] max-desktop:h-[12px] max-desktop:w-[16px]' />
-                  ) : null}
-                </p>
-              </button>
-            </Link>
-          );
-        })}
-      </div>
-    );
-  }
-  return null;
+        return (
+          <Link href={`/dashboard/${dashboard.id}`} key={index}>
+            <button
+              onClick={() => handleButtonColor(index)}
+              className={`${
+                buttonColor === index ? "bg-[#F1EFFD]" : "bg-none"
+              } flex h-[45px] w-[276px] cursor-pointer items-center justify-start rounded-[4px] hover:bg-[#F1EFFD] max-desktop:w-[134px] max-tablet:w-fit`}
+            >
+              <ColorChip fill={color} />
+              <p className='flex items-center justify-start gap-2 truncate text-gray-50 max-desktop:gap-1.5 max-tablet:hidden'>
+                {title}
+                {dashboard.createdByMe ? (
+                  <CrownIcon className='viewBox-[0 0 18 14] h-[14px] w-[18px] max-desktop:h-[12px] max-desktop:w-[16px]' />
+                ) : null}
+              </p>
+            </button>
+          </Link>
+        );
+      })}
+    </div>
+  );
 };
 
 export default ButtonList;

--- a/components/SideMenu/CreateDashBoardModal.tsx
+++ b/components/SideMenu/CreateDashBoardModal.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import CreateDashBoard from "@/components/Modal/CreateDashBoard/CreateDashBoard";
+import useDashboard from "@/hooks/useDashboard";
+
+interface DashboardModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const DashboardModal: React.FC<DashboardModalProps> = ({ isOpen, onClose }) => {
+  const [inputValue, setInputValue] = useState("");
+  const { addDashboard } = useDashboard();
+
+  const colors: { [key: string]: string } = {
+    green: "#7AC555",
+    purple: "#760DDE",
+    orange: "#FFA500",
+    blue: "#76A5EA",
+    pink: "#E876EA",
+  };
+
+  const postDashboard = (
+    e: React.FormEvent<HTMLFormElement>,
+    color: string,
+  ) => {
+    e.preventDefault();
+    const colorCode = colors[color];
+    addDashboard({ title: inputValue, color: colorCode });
+    onClose(); // 모달 닫기
+  };
+
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  return (
+    <CreateDashBoard
+      isOpen={isOpen}
+      title={"새로운 대시보드"}
+      value={inputValue}
+      subTitle={"대시보드 이름"}
+      placeholder={"대시보드 이름"}
+      createButtonText={"생성"}
+      cancelButtonText={"취소"}
+      onClose={onClose}
+      onSubmit={postDashboard}
+      onChange={handleChangeInput}
+    />
+  );
+};
+
+export default DashboardModal;

--- a/components/SideMenu/CreateDashBoardModal.tsx
+++ b/components/SideMenu/CreateDashBoardModal.tsx
@@ -26,6 +26,7 @@ const DashboardModal: React.FC<DashboardModalProps> = ({ isOpen, onClose }) => {
     e.preventDefault();
     const colorCode = colors[color];
     addDashboard({ title: inputValue, color: colorCode });
+    setInputValue(""); // 입력 필드 초기화
     onClose(); // 모달 닫기
   };
 

--- a/hooks/useDashboard.ts
+++ b/hooks/useDashboard.ts
@@ -81,11 +81,7 @@ const useDashboard = () => {
     },
   };
 
-  const { mutate: addDashboard } = useMutation<
-    DashboardResponse,
-    Error,
-    CreateDashboardRequest
-  >(mutationOptions);
+  const { mutate: addDashboard } = useMutation(mutationOptions);
 
   // 대시보드 수정
   const updateDashboard = async (

--- a/hooks/useDashboard.ts
+++ b/hooks/useDashboard.ts
@@ -1,0 +1,135 @@
+/*
+    useDashboard: 조회, 생성, 수정, 삭제 기능
+*/
+
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  UseMutationOptions,
+} from "@tanstack/react-query";
+import fetcher from "@/lib/api/fetcher";
+import { AxiosRequestConfig } from "axios";
+import {
+  CreateDashboardRequest,
+  DashboardResponse,
+  DashboardsResponse,
+  UpdateDashboardRequest,
+  GetDashboardsRequest,
+} from "@/lib/api/types/dashboards";
+
+const useDashboard = () => {
+  const queryClient = useQueryClient();
+
+  // 대시보드 리스트 조회
+  const fetchDashboards = async (
+    params: GetDashboardsRequest,
+  ): Promise<DashboardsResponse> => {
+    try {
+      return await fetcher<DashboardsResponse>({
+        url: "/dashboards",
+        params: params,
+      });
+    } catch (error) {
+      throw new Error("Failed to fetch dashboards");
+    }
+  };
+
+  const queryKey = [
+    "dashboards",
+    { navigationMethod: "pagination", page: 1, size: 10 },
+  ];
+  const initialData = queryClient.getQueryData<DashboardsResponse>(queryKey);
+
+  const { data, error, isLoading } = useQuery<DashboardsResponse, Error>({
+    queryKey,
+    queryFn: () =>
+      fetchDashboards({ navigationMethod: "pagination", page: 1, size: 10 }),
+    initialData,
+  });
+
+  const displayData = isLoading && initialData ? initialData : data;
+
+  // 대시보드 생성
+  const createDashboard = async (
+    dashboardData: CreateDashboardRequest,
+  ): Promise<DashboardResponse> => {
+    try {
+      return await fetcher<DashboardResponse>({
+        url: "/dashboards",
+        method: "POST",
+        data: dashboardData,
+      });
+    } catch (error) {
+      throw new Error("Failed to create dashboard");
+    }
+  };
+
+  const mutationOptions: UseMutationOptions<
+    DashboardResponse,
+    Error,
+    CreateDashboardRequest
+  > = {
+    mutationFn: createDashboard,
+    onSuccess: () => {
+      // 대시보드 생성이 성공한 후 대시보드 목록 쿼리를 무효화
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+    onError: (error: Error) => {
+      console.error("Create dashboard failed:", error);
+    },
+  };
+
+  // 대시보드 수정
+  const updateDashboard = async (
+    dashboardId: number,
+    dashboardData: UpdateDashboardRequest,
+  ): Promise<DashboardResponse> => {
+    return fetcher<DashboardResponse>({
+      url: `/dashboards/${dashboardId}`,
+      method: "PUT",
+      data: dashboardData,
+    });
+  };
+
+  const { mutate: editDashboard } = useMutation<
+    DashboardResponse,
+    Error,
+    { dashboardId: number; dashboardData: UpdateDashboardRequest }
+  >({
+    mutationFn: ({ dashboardId, dashboardData }) =>
+      updateDashboard(dashboardId, dashboardData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+    onError: (error) => {
+      console.error("Update failed", error);
+    },
+  });
+
+  // 대시보드 삭제
+  const deleteDashboard = async (
+    dashboardId: number,
+  ): Promise<{ message: string }> => {
+    return fetcher<{ message: string }>({
+      url: `/dashboards/${dashboardId}`,
+      method: "DELETE",
+    });
+  };
+
+  const { mutate: removeDashboard } = useMutation<
+    { message: string },
+    Error,
+    number
+  >({
+    mutationFn: deleteDashboard,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
+    },
+    onError: (error) => {
+      console.error("Delete dashboard failed", error);
+    },
+  });
+};
+
+export default useDashboard;

--- a/hooks/useDashboard.ts
+++ b/hooks/useDashboard.ts
@@ -65,6 +65,7 @@ const useDashboard = () => {
     }
   };
 
+  // 대시보드 생성 mutation 옵션
   const mutationOptions: UseMutationOptions<
     DashboardResponse,
     Error,
@@ -79,6 +80,12 @@ const useDashboard = () => {
       console.error("Create dashboard failed:", error);
     },
   };
+
+  const { mutate: addDashboard } = useMutation<
+    DashboardResponse,
+    Error,
+    CreateDashboardRequest
+  >(mutationOptions);
 
   // 대시보드 수정
   const updateDashboard = async (
@@ -130,6 +137,14 @@ const useDashboard = () => {
       console.error("Delete dashboard failed", error);
     },
   });
+  return {
+    dashboards: displayData?.dashboards,
+    isLoading,
+    error,
+    addDashboard,
+    editDashboard,
+    removeDashboard,
+  };
 };
 
 export default useDashboard;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.45.1",
+    "@tanstack/react-query": "^5.50.1",
     "@tanstack/react-query-devtools": "^5.45.1",
     "@types/react-datepicker": "^6.2.0",
     "axios": "^1.7.2",

--- a/pages/dashboard/[dashboardId]/edit.tsx
+++ b/pages/dashboard/[dashboardId]/edit.tsx
@@ -7,32 +7,31 @@ import BackLink from "@/components/MyPage/BackLink";
 import Button from "@/components/Button";
 import DeleteModal from "@/components/Modal/AlarmModal";
 import React, { useState } from "react";
-import fetcher from "@/lib/api/fetcher";
+import useDashboard from "@/hooks/useDashboard";
 
 const DashboardEditPage = () => {
   const router = useRouter();
   const { dashboardId } = router.query;
+  const dashboardIdNumber = Number(dashboardId); //router로 dashboardId가 넘어오면 string으로 변환되어 Number로 전환
+
+  const { removeDashboard } = useDashboard(); // useDashboard 훅 사용
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const dashboardIdNumber = Number(dashboardId); //router로 dashboardId가 넘어오기 때문에 string으로 변환됨
 
   if (!dashboardId || isNaN(dashboardIdNumber)) {
     return <div>유효하지 않은 대시보드 ID</div>;
   }
 
   const handleDelete = async () => {
-    try {
-      await fetcher({
-        url: `/dashboards/${dashboardId}`,
-        method: "DELETE",
-      });
-
-      console.log(`${dashboardId} 삭제되었습니다.`);
-      router.push("/mydashboard");
-    } catch (error) {
-      console.error("오류가 발생했습니다:", error);
-    }
+    removeDashboard(dashboardIdNumber, {
+      onSuccess: () => {
+        console.log(`${dashboardId} 삭제되었습니다.`);
+        router.push("/mydashboard");
+      },
+      onError: (error: Error) => {
+        console.error("오류가 발생했습니다:", error);
+      },
+    });
   };
 
   const handleOpenModal = () => {

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -1,7 +1,7 @@
 import DashboardLayout from "@/components/Layout/DashboardLayout";
 import AddButton from "@/components/Button/AddButton/AddButton";
 import ListButton from "@/components/Button/ListButton/ListButton";
-import CreateDashBoard from "@/components/Modal/CreateDashBoard/CreateDashBoard";
+import CreateDashBoardModal from "@/components/SideMenu/CreateDashBoardModal"; // 수정된 부분
 import InvitedDashboard from "@/components/Table/InvitedDashboard/InvitedDashboard";
 import { useRouter } from "next/router";
 import { useState, useEffect, ChangeEvent } from "react";
@@ -35,6 +35,8 @@ export default function MyDashBoard() {
   const postDashboard = (e: React.FormEvent, color: string) => {
     e.preventDefault();
     addDashboard({ title: inputValue, color });
+    setIsModalOpen(false); // 모달 닫기
+    setInputValue(""); //입력필드 초기화
   };
 
   if (isLoading) {
@@ -65,43 +67,35 @@ export default function MyDashBoard() {
               onClick={() => {
                 setIsModalOpen(true);
               }}
-              children='새로운 대시보드'
-            />
+            >
+              새로운 대시보드
+            </AddButton>
 
             {/* 대시보드 버튼 목록 */}
             {dashboards.slice(startDashboard, endDashboard).map((dashboard) => (
               <ListButton
                 className='mb-[8px] w-full tablet:mx-[5px] tablet:my-[5px] desktop:w-332'
+                key={dashboard.id}
                 children={dashboard.title}
                 createdByMe={dashboard.createdByMe}
                 onClick={() => {
                   router.push(`/dashboard/${dashboard.id}`);
                 }}
-                key={dashboard.id}
               />
             ))}
           </div>
+
           {/* 페이지네이션 구현 */}
           <div className='mx-[24px] w-full px-[48px] tablet:mx-[20px] tablet:mb-[40px] tablet:px-[40px] desktop:w-[1022px] desktop:px-0'>
             {dashboards.length > 0 && renderPaginationButtons()}
           </div>
 
           {/* 대시보드 생성 모달창 */}
-          <CreateDashBoard
+          <CreateDashBoardModal
             isOpen={isModalOpen}
-            title='새로운 대시보드'
-            value={inputValue}
-            subTitle='대시보드 이름'
-            placeholder='대시보드 이름'
-            createButtonText='생성'
-            cancelButtonText='취소'
             onClose={() => {
               setIsModalOpen(false);
             }}
-            onSubmit={() => {
-              postDashboard;
-            }}
-            onChange={handleChangeInput}
           />
 
           {/* 초대받은 대시보드 - 있는 경우와 없는 경우에 따른 구현 */}

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -5,134 +5,48 @@ import CreateDashBoard from "@/components/Modal/CreateDashBoard/CreateDashBoard"
 import InvitedDashboard from "@/components/Table/InvitedDashboard/InvitedDashboard";
 import { useRouter } from "next/router";
 import { useState, useEffect, ChangeEvent } from "react";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
-import { DashboardsResponse } from "@/lib/api/types/dashboards";
-import fetcher from "@/lib/api/fetcher";
-import { AxiosRequestConfig } from "axios";
+import useDashboard from "@/hooks/useDashboard";
 import usePagination from "@/components/Pagination/usePagination";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CreateDashboardRequest, DashboardResponse } from "@/lib/api/types/dashboards";
-
 
 export default function MyDashBoard() {
   const router = useRouter();
-  const [inputValue, setInputValue] = useState('')
-
+  const [inputValue, setInputValue] = useState("");
+  const { dashboards, isLoading, error, addDashboard } = useDashboard();
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
-    setNewDashboardTitle(e.target.value);
+    setInputValue(e.target.value);
   };
 
-  // data per page
+  // Pagination
   const pageSize = 5;
-
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [newDashBoardTitle, setNewDashboardTitle] = useState("");
-
-  const getDashboardList = async (currentPage?: number, pageSize?: number) => {
-    const response = await fetcher<DashboardsResponse>({
-      url: "/dashboards",
-      params: {
-        navigationMethod: "pagination",
-        page: currentPage,
-        size: 5,
-      },
-    });
-    return response;
-  };
-
   const [totalCount, setTotalCount] = useState(0);
-
-  // usePagination
   const { currentPage, renderPaginationButtons } = usePagination({
     totalCount,
     pageSize,
   });
 
-  const { data } = useQuery<DashboardsResponse>({
-    queryKey: ["dashBoards", currentPage, pageSize],
-    queryFn: () => getDashboardList(currentPage, pageSize),
-    placeholderData: keepPreviousData,
-    staleTime: 1000,
-  });
-
   useEffect(() => {
-    if (!data?.totalCount) return;
-    setTotalCount(data?.totalCount);
-  }, [data?.totalCount]);
-
-  const config: AxiosRequestConfig = {
-    url: "/dashboards",
-    method: "GET",
-    params: {
-      navigationMethod: "pagination",
-    },
-  };
-
-  const {
-    data: dashboardData,
-    error: dashboardError,
-    isLoading: dashboardloading,
-  } = useQuery<DashboardsResponse>({
-    queryKey: ["DashboardsResponse"],
-    queryFn: () => fetcher<DashboardsResponse>(config),
-  });
-
-  const queryClient = useQueryClient();
-
-  const mutation = useMutation<DashboardResponse, Error,CreateDashboardRequest>({
-    mutationFn: async (title) => {
-      const response = await fetcher<DashboardResponse>({
-        url: "/dashboards",
-        method: "POST",
-        data: title,
-      });
-      return response;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["titles"]
-      })},
-      onError: (error) => {
-          console.error(error)
-        }
+    if (dashboards) {
+      setTotalCount(dashboards.length);
     }
-  )
+  }, [dashboards]);
+
   const postDashboard = (e: React.FormEvent, color: string) => {
-    // 자식 컴포넌트가 부모 컴포넌트한테 값을 전달해주려면
-    // 함수를 통해, (함수의 parameter를 통해) 전달이 가능하다!
     e.preventDefault();
-    mutation.mutate({title: inputValue, color})
+    addDashboard({ title: inputValue, color });
   };
 
-  const BoardButtons = () => {
-    return dashboardArray
-      .slice(startDashboard - 1, endDashboard)
-      .map((dashboard) => (
-        <ListButton
-          className='mb-[8px] w-full tablet:mx-[5px] tablet:my-[5px] desktop:w-332'
-          children={dashboard.title}
-          createdByMe={dashboard.createdByMe}
-          onClick={() => {
-            router.push(`/dashboard/${dashboard.id}`);
-          }}
-          key={dashboard.id}
-        />
-      ));
-  };
-
-  const PaginationButtons = renderPaginationButtons();
-
-  if (dashboardloading) {
+  if (isLoading) {
     return <div>Loading...</div>;
   }
-  if (dashboardError || !dashboardData) {
-    return null;
-  }
-  const dashboardArray = dashboardData.dashboards;
 
-  const startDashboard = (currentPage - 1) * pageSize + 1;
-  const endDashboard = startDashboard + pageSize - 1;
+  if (error || !dashboards) {
+    return <div>Error loading dashboards</div>;
+  }
+
+  const startDashboard = (currentPage - 1) * pageSize;
+  const endDashboard = startDashboard + pageSize;
 
   return (
     <>
@@ -155,19 +69,28 @@ export default function MyDashBoard() {
             />
 
             {/* 대시보드 버튼 목록 */}
-            <BoardButtons />
+            {dashboards.slice(startDashboard, endDashboard).map((dashboard) => (
+              <ListButton
+                className='mb-[8px] w-full tablet:mx-[5px] tablet:my-[5px] desktop:w-332'
+                children={dashboard.title}
+                createdByMe={dashboard.createdByMe}
+                onClick={() => {
+                  router.push(`/dashboard/${dashboard.id}`);
+                }}
+                key={dashboard.id}
+              />
+            ))}
           </div>
-
           {/* 페이지네이션 구현 */}
           <div className='mx-[24px] w-full px-[48px] tablet:mx-[20px] tablet:mb-[40px] tablet:px-[40px] desktop:w-[1022px] desktop:px-0'>
-            {data?.totalCount !== 0 && PaginationButtons}
+            {dashboards.length > 0 && renderPaginationButtons()}
           </div>
 
           {/* 대시보드 생성 모달창 */}
           <CreateDashBoard
             isOpen={isModalOpen}
             title='새로운 대시보드'
-            value={newDashBoardTitle}
+            value={inputValue}
             subTitle='대시보드 이름'
             placeholder='대시보드 이름'
             createButtonText='생성'
@@ -175,7 +98,9 @@ export default function MyDashBoard() {
             onClose={() => {
               setIsModalOpen(false);
             }}
-            onSubmit={() => {postDashboard}}
+            onSubmit={() => {
+              postDashboard;
+            }}
             onChange={handleChangeInput}
           />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,10 +1407,10 @@
     content-type "^1.0.5"
     tslib "^2.6.2"
 
-"@tanstack/query-core@5.49.1":
-  version "5.49.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.49.1.tgz#09167842123eddaf47465376f3c835cf59b9f1e9"
-  integrity sha512-JnC9ndmD1KKS01Rt/ovRUB1tmwO7zkyXAyIxN9mznuJrcNtOrkmOnQqdJF2ib9oHzc2VxHomnEG7xyfo54Npkw==
+"@tanstack/query-core@5.50.1":
+  version "5.50.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.50.1.tgz#b3f93e34cc9cdc46891a1a07a42a0ed2d0a77578"
+  integrity sha512-lpfhKPrJlyV2DSVcQb/HuozH3Av3kws4ge22agx+lNGpFkS4vLZ7St0l3GLwlAD+bqB+qXGex3JdRKUNtMviEQ==
 
 "@tanstack/query-devtools@5.49.1":
   version "5.49.1"
@@ -1424,12 +1424,12 @@
   dependencies:
     "@tanstack/query-devtools" "5.49.1"
 
-"@tanstack/react-query@^5.45.1":
-  version "5.49.2"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.49.2.tgz#d9c08f8eb62890f5274608f8954ab1709912ef3c"
-  integrity sha512-6rfwXDK9BvmHISbNFuGd+wY3P44lyW7lWiA9vIFGT/T0P9aHD1VkjTvcM4SDAIbAQ9ygEZZoLt7dlU1o3NjMVA==
+"@tanstack/react-query@^5.50.1":
+  version "5.50.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.50.1.tgz#2eb6f552e3ff108f532da4fab5bcaef71ed0ab03"
+  integrity sha512-s0DW3rVBDPReDDovUjVqItVa3R2nPfUANK9nqGvarO2DwTiY9U4EBTsqizMxItRCoGgK5apeM7D3mxlHrSKpdQ==
   dependencies:
-    "@tanstack/query-core" "5.49.1"
+    "@tanstack/query-core" "5.50.1"
 
 "@trysound/sax@0.2.0":
   version "0.2.0"
@@ -4138,8 +4138,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4211,7 +4219,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
💻 제목 - Refactor: Dashboard 데이터 호출 구조 개선 & 캐싱 무효화 처리

## 🔎 작업 내용
- useDashboard 훅: side bar & myDashboard & dashboardId/edit page에서 대시보드 관련 데이터 전송하는 거 하나의 파일로 합침
- 캐싱 무효화 처리하여, 새로운 대시보드 생성 & 삭제시 새로고침하지 않아도 바로 반영됨

## 📜 간단한 코드 설명 및 사용설명서
- useDashboard 훅 만듬
- 예은님이 만든 AddDashBoardButton 컴포넌트, side menu의 UI부분과 모달창 부분으로 컴포넌트 나눴습니다.
 
## 📷 결과물 (image , gif ..)
- 프리뷰로 확인해주세요 ㅠㅠ,,

### 👀 공유포인트 및 이슈
- 힘들어,,,