### PR TITLE
Refactor: 할일카드 생성하면 바로 화면에 업데이트 되도록 캐시 무효화

### DIFF
--- a/components/Modal/CardDetailsModal/hooks/useCardDetailsModal.ts
+++ b/components/Modal/CardDetailsModal/hooks/useCardDetailsModal.ts
@@ -1,36 +1,23 @@
 /*
 CardDetailsModal을 위한 custom Hook: 모달 상태 관리, 데이터 가져오기 로직
 */
-import { useQuery } from "@tanstack/react-query";
-import fetcher from "@/lib/api/fetcher";
-import { FetchCardDetailsResponse } from "@/lib/api/types/cards";
 import useModal from "@/hooks/useModal";
-import { AxiosRequestConfig } from "axios";
+import useCards from "@/hooks/useCards";
 import { useEffect } from "react";
 
 const useCardDetailsModal = (isOpen: boolean, cardId: number) => {
+  const { fetchCardDetails } = useCards();
   const {
     isOpen: modalIsOpen,
     openModal,
     closeModal,
   } = useModal(isOpen, cardId);
-
   const {
     data: cardDetails,
     error,
     isLoading,
     refetch,
-  } = useQuery<FetchCardDetailsResponse>({
-    queryKey: ["cardDetails", cardId],
-    queryFn: async () => {
-      const config: AxiosRequestConfig = {
-        url: `/cards/${cardId}`,
-        method: "GET",
-      };
-      return fetcher<FetchCardDetailsResponse>(config);
-    },
-    enabled: isOpen,
-  });
+  } = fetchCardDetails(cardId);
 
   useEffect(() => {
     if (isOpen) {

--- a/components/Modal/CardDetailsModal/index.tsx
+++ b/components/Modal/CardDetailsModal/index.tsx
@@ -8,6 +8,7 @@ import useCardDetailsModal from "./hooks/useCardDetailsModal";
 import Header from "./components/Header";
 import Body from "./components/Body";
 import CardEditModal from "../CardModal/CardEditModal";
+import useCards from "@/hooks/useCards";
 
 export interface ModalProps {
   isOpen: boolean;
@@ -42,6 +43,7 @@ const CardDetailsModal: FC<CardDetailsModalProps> = ({
   const queryClient = useQueryClient();
   const { modalIsOpen, isLoading, error, cardDetails, refetch } =
     useCardDetailsModal(isOpen, cardId);
+  const { deleteCard } = useCards();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   const handleSuccess = () => {
@@ -56,9 +58,14 @@ const CardDetailsModal: FC<CardDetailsModalProps> = ({
     setIsEditModalOpen(true);
   };
 
-  const handleDelete = () => {
-    onClose(); // CardDetailsModal 닫기
-    window.location.reload(); // 페이지 리로드하여 최신 데이터 반영
+  const handleDelete = async () => {
+    try {
+      await deleteCard.mutateAsync(cardId);
+      onClose(); // CardDetailsModal 닫기
+      handleSuccess(); // 성공 시 데이터 갱신
+    } catch (error) {
+      console.error("Failed to delete card:", error);
+    }
   };
 
   return (

--- a/hooks/useCards.ts
+++ b/hooks/useCards.ts
@@ -41,7 +41,7 @@ const useCards = () => {
       const formData = new FormData();
       formData.append("image", file);
       const imgResponse = await fetcher<UploadCardImageResponse>({
-        url: `/cards/images/upload`,
+        url: `columns/${cardData.columnId}/card-image`,
         method: "POST",
         data: formData,
         headers: { "Content-Type": "multipart/form-data" },
@@ -121,7 +121,7 @@ const useCards = () => {
 
   return {
     fetchCards,
-    createCard,
+    createCardMutation,
     fetchCardDetails,
     updateCard,
     deleteCard,

--- a/hooks/useCards.ts
+++ b/hooks/useCards.ts
@@ -28,33 +28,29 @@ const useCards = () => {
     });
   };
 
-  // 카드 생성 및 이미지 업로드
-  const createCard = async (cardData: CreateCardData, file?: File) => {
+  // 카드 생성 및 이미지 업로드 통합 로직
+  const createCard = async ({
+    cardData,
+    file,
+  }: {
+    cardData: CreateCardData;
+    file?: File;
+  }) => {
     let imageUrl = "";
-
-    // 이미지가 제공된 경우 먼저 업로드
     if (file) {
       const formData = new FormData();
       formData.append("image", file);
       const imgResponse = await fetcher<UploadCardImageResponse>({
-        url: `/cards/images/upload`, // 예시 URL, 실제 API 경로에 따라 수정 필요
+        url: `/cards/images/upload`,
         method: "POST",
         data: formData,
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
+        headers: { "Content-Type": "multipart/form-data" },
       });
       imageUrl = imgResponse.imageUrl;
     }
 
-    // 카드 데이터에 이미지 URL 추가
-    const completeCardData = {
-      ...cardData,
-      ...(imageUrl && { imageUrl }),
-    };
-
-    // 카드 생성 요청
-    await fetcher<FetchCardDetailsResponse>({
+    const completeCardData = { ...cardData, ...(imageUrl && { imageUrl }) };
+    await fetcher<void>({
       url: "/cards",
       method: "POST",
       data: completeCardData,
@@ -68,13 +64,12 @@ const useCards = () => {
     Error,
     { cardData: CreateCardData; file?: File }
   >({
-    mutationFn: ({ cardData, file }) => createCard(cardData, file),
+    mutationFn: createCard,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cardsData"] });
     },
     onError: (error) => {
       console.error("Error creating card with image:", error);
-      throw error;
     },
   });
 

--- a/hooks/useCards.ts
+++ b/hooks/useCards.ts
@@ -125,20 +125,21 @@ const useCards = () => {
   });
 
   // 카드 삭제
-  const deleteCard = (cardId: number) => {
-    return useMutation<{ message: string }, Error, number>({
-      mutationKey: ["deleteCard", cardId],
-      mutationFn: () =>
-        fetcher<{ message: string }>({
-          url: `/cards/${cardId}`,
-          method: "DELETE",
-        }),
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["cardDetails", cardId] });
-        queryClient.invalidateQueries({ queryKey: ["cardsData"] });
-      },
-    });
-  };
+  const deleteCard = useMutation<{ message: string }, Error, number>({
+    mutationFn: async (cardId) => {
+      return await fetcher<{ message: string }>({
+        url: `/cards/${cardId}`,
+        method: "DELETE",
+      });
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["cardDetails", variables] });
+      queryClient.invalidateQueries({ queryKey: ["cardsData"] });
+    },
+    onError: (error) => {
+      console.error("Failed to delete card", error);
+    },
+  });
 
   return {
     fetchCards,

--- a/hooks/useCards.ts
+++ b/hooks/useCards.ts
@@ -1,0 +1,101 @@
+/*
+   useCards: 카드 목록 조회, 상세 조회, 생성, 수정, 삭제 기능
+*/
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import fetcher from "@/lib/api/fetcher";
+import {
+  CreateCardData,
+  FetchCardsResponse,
+  UpdateCardData,
+  FetchCardDetailsResponse,
+  DeleteCardData,
+} from "@/lib/api/types/cards";
+
+const useCards = () => {
+  const queryClient = useQueryClient();
+
+  // 카드 목록 조회
+  const fetchCards = (columnId: number) => {
+    const cardsConfig = {
+      url: `/cards?size=10&columnId=${columnId}`,
+      method: "GET",
+    };
+    return useQuery<FetchCardsResponse, Error>({
+      queryKey: ["cardsData", columnId],
+      queryFn: () => fetcher<FetchCardsResponse>(cardsConfig),
+      enabled: !!columnId,
+    });
+  };
+
+  // 카드 생성
+  const createCard = (cardData: CreateCardData) => {
+    const createConfig = {
+      url: "/cards",
+      method: "POST",
+      data: cardData,
+    };
+    return useMutation<FetchCardDetailsResponse, Error, CreateCardData>({
+      mutationKey: ["createCard"],
+      mutationFn: () => fetcher<FetchCardDetailsResponse>(createConfig),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["cardsData"] });
+      },
+    });
+  };
+
+  // 카드 상세 조회
+  const fetchCardDetails = (cardId: number) => {
+    const detailConfig = {
+      url: `/cards/${cardId}`,
+      method: "GET",
+    };
+    return useQuery<FetchCardDetailsResponse, Error>({
+      queryKey: ["cardDetails", cardId],
+      queryFn: () => fetcher<FetchCardDetailsResponse>(detailConfig),
+      enabled: !!cardId,
+    });
+  };
+
+  // 카드 수정
+  const updateCard = (cardId: number, cardData: UpdateCardData) => {
+    const updateConfig = {
+      url: `/cards/${cardId}`,
+      method: "PUT",
+      data: cardData,
+    };
+    return useMutation<FetchCardDetailsResponse, Error, UpdateCardData>({
+      mutationKey: ["updateCard", cardId],
+      mutationFn: () => fetcher<FetchCardDetailsResponse>(updateConfig),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["cardDetails", cardId] });
+        queryClient.invalidateQueries({ queryKey: ["cardsData"] });
+      },
+    });
+  };
+
+  // 카드 삭제
+  const deleteCard = (cardId: number) => {
+    const deleteConfig = {
+      url: `/cards/${cardId}`,
+      method: "DELETE",
+    };
+    return useMutation<{ message: string }, Error, number>({
+      mutationKey: ["deleteCard", cardId],
+      mutationFn: () => fetcher<{ message: string }>(deleteConfig),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["cardDetails", cardId] });
+        queryClient.invalidateQueries({ queryKey: ["cardsData"] });
+      },
+    });
+  };
+
+  return {
+    fetchCards,
+    createCard,
+    fetchCardDetails,
+    updateCard,
+    deleteCard,
+  };
+};
+
+export default useCards;


### PR DESCRIPTION
💻 제목 - Refactor: 할일카드 생성하면 바로 화면에 업데이트 되도록 캐시 무효화

## 🔎 작업 내용
- useCards 훅 만들었고,
- 모든 카드 모달(할일 생성, 할일 상세, 할일 수정 모달)에 적용했습니다.

## 📜 간단한 코드 설명 및 사용설명서


## 📷 결과물 (image , gif ..)
- 프리뷰 확인해주세요

### 👀 공유포인트 및 이슈
